### PR TITLE
Support zvbdota

### DIFF
--- a/auto-generated/api-testing/vfbdota.c
+++ b/auto-generated/api-testing/vfbdota.c
@@ -1,0 +1,94 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                       vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                       vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                       vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                       vl);
+}

--- a/auto-generated/api-testing/vfqwbdota.c
+++ b/auto-generated/api-testing/vfqwbdota.c
@@ -1,0 +1,258 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}

--- a/auto-generated/api-testing/vfwbdota.c
+++ b/auto-generated/api-testing/vfwbdota.c
@@ -1,0 +1,62 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1(vfloat32m1_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2(vfloat32m2_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4(vfloat32m4_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8(vfloat32m8_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vbool32_t vm,
+                                                    vfloat32m1_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vbool16_t vm,
+                                                    vfloat32m2_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vbool8_t vm,
+                                                    vfloat32m4_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vbool4_t vm,
+                                                    vfloat32m8_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/api-testing/vqwbdota.c
+++ b/auto-generated/api-testing/vqwbdota.c
@@ -1,0 +1,354 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1(vint32m1_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2(vint32m2_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4(vint32m4_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8(vint32m8_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1(vuint32m1_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2(vuint32m2_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4(vuint32m4_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8(vuint32m8_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_m(vbool32_t vm, vuint32m1_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_m(vbool16_t vm, vuint32m2_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_m(vbool8_t vm, vuint32m4_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_m(vbool4_t vm, vuint32m8_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1(vint64m1_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2(vint64m2_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4(vint64m4_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8(vint64m8_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1(vuint64m1_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2(vuint64m2_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4(vuint64m4_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8(vuint64m8_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_m(vbool64_t vm, vuint64m1_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_m(vbool32_t vm, vuint64m2_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_m(vbool16_t vm, vuint64m4_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_m(vbool8_t vm, vuint64m8_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_m(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/gnu-api-tests/vfbdota.c
+++ b/auto-generated/gnu-api-tests/vfbdota.c
@@ -1,0 +1,69 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1(vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2(vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4(vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm(vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm(vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm(vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfbdota\.[ivxfswum.]+\s+} 16 } } */

--- a/auto-generated/gnu-api-tests/vfqwbdota.c
+++ b/auto-generated/gnu-api-tests/vfqwbdota.c
@@ -1,0 +1,133 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfqwbdota\.[ivxfswum.]+\s+} 32 } } */

--- a/auto-generated/gnu-api-tests/vfwbdota.c
+++ b/auto-generated/gnu-api-tests/vfwbdota.c
@@ -1,0 +1,37 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1(vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2(vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4(vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8(vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfwbdota\.[ivxfswum.]+\s+} 8 } } */

--- a/auto-generated/gnu-api-tests/vqwbdota.c
+++ b/auto-generated/gnu-api-tests/vqwbdota.c
@@ -1,0 +1,261 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2(vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4(vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8(vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2(vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4(vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8(vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1(vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2(vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4(vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8(vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1(vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2(vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4(vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8(vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1(vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2(vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4(vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8(vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1(vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2(vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4(vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8(vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1(vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2(vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4(vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8(vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1(vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2(vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4(vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8(vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_m(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_m(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_m(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_m(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_m(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_m(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_m(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_m(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vqwbdota\.[ivxfswum.]+\s+} 64 } } */

--- a/auto-generated/gnu-overloaded-tests/vfbdota.c
+++ b/auto-generated/gnu-overloaded-tests/vfbdota.c
@@ -1,0 +1,69 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1(vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2(vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4(vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm(vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm(vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm(vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfbdota\.[ivxfswum.]+\s+} 16 } } */

--- a/auto-generated/gnu-overloaded-tests/vfqwbdota.c
+++ b/auto-generated/gnu-overloaded-tests/vfqwbdota.c
@@ -1,0 +1,133 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfqwbdota\.[ivxfswum.]+\s+} 32 } } */

--- a/auto-generated/gnu-overloaded-tests/vfwbdota.c
+++ b/auto-generated/gnu-overloaded-tests/vfwbdota.c
@@ -1,0 +1,37 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1(vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2(vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4(vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8(vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfwbdota\.[ivxfswum.]+\s+} 8 } } */

--- a/auto-generated/gnu-overloaded-tests/vqwbdota.c
+++ b/auto-generated/gnu-overloaded-tests/vqwbdota.c
@@ -1,0 +1,261 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2(vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4(vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8(vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2(vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4(vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8(vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1(vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2(vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4(vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8(vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1(vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2(vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4(vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8(vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1(vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2(vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4(vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8(vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1(vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2(vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4(vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8(vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1(vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2(vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4(vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8(vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1(vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2(vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4(vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8(vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_m(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_m(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_m(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_m(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_m(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_m(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_m(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_m(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vqwbdota\.[ivxfswum.]+\s+} 64 } } */

--- a/auto-generated/intrinsic_funcs.adoc
+++ b/auto-generated/intrinsic_funcs.adoc
@@ -54624,3 +54624,469 @@ vfloat32m1_t __riscv_vfqwdota_vv_f8e5m2m8_f8e5m2m8_f32m1_m(vbool1_t vm,
                                                            vfloat8e5m2m8_t vs1,
                                                            size_t vl);
 ----
+
+=== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[[zvqwbdota8i-8-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1(vint32m1_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2(vint32m2_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4(vint32m4_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8(vint32m8_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1(vuint32m1_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t ci,
+                                                size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2(vuint32m2_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t ci,
+                                                size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4(vuint32m4_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t ci,
+                                                size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8(vuint32m8_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t ci,
+                                                size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_m(vbool32_t vm, vuint32m1_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_m(vbool16_t vm, vuint32m2_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_m(vbool8_t vm, vuint32m4_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_m(vbool4_t vm, vuint32m8_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+----
+
+=== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[[zvqwbdota16i-16-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1(vint64m1_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2(vint64m2_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4(vint64m4_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8(vint64m8_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1(vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2(vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4(vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8(vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t ci,
+                                                  size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_m(vbool64_t vm,
+                                                    vuint64m1_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_m(vbool32_t vm,
+                                                    vuint64m2_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_m(vbool16_t vm,
+                                                    vuint64m4_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_m(vbool8_t vm, vuint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+----
+
+=== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[[zvfwbdota16bf-bf16-batched-widening-dot-product]]
+==== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1(vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2(vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4(vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8(vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vbool32_t vm,
+                                                       vfloat32m1_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vbool16_t vm,
+                                                       vfloat32m2_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vbool8_t vm,
+                                                       vfloat32m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vbool4_t vm,
+                                                       vfloat32m8_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t ci, size_t vl);
+----
+
+=== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[[zvfqwbdota8f-fp8-batched-quad-widening-dot-product]]
+==== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+----
+
+=== Zvfbdota32f - FP32 Batched Dot Product
+
+[[zvfbdota32f-fp32-batched-dot-product]]
+==== Zvfbdota32f - FP32 Batched Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfbdota_vv_f32m1(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         unsigned int frm, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, unsigned int frm,
+                                           size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, unsigned int frm,
+                                           size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, unsigned int frm,
+                                           size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, unsigned int frm,
+                                           size_t vl);
+----

--- a/auto-generated/intrinsic_funcs/19_zvqwbdota8i_-_8-bit_integer_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/intrinsic_funcs/19_zvqwbdota8i_-_8-bit_integer_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,110 @@
+
+=== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[[zvqwbdota8i-8-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1(vint32m1_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2(vint32m2_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4(vint32m4_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8(vint32m8_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t ci,
+                                               size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1(vuint32m1_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t ci,
+                                                size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2(vuint32m2_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t ci,
+                                                size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4(vuint32m4_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t ci,
+                                                size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8(vuint32m8_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t ci,
+                                                size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_m(vbool32_t vm, vuint32m1_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_m(vbool16_t vm, vuint32m2_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_m(vbool8_t vm, vuint32m4_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_m(vbool4_t vm, vuint32m8_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+----

--- a/auto-generated/intrinsic_funcs/20_zvqwbdota16i_-_16-bit_integer_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/intrinsic_funcs/20_zvqwbdota16i_-_16-bit_integer_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,129 @@
+
+=== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[[zvqwbdota16i-16-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1(vint64m1_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2(vint64m2_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4(vint64m4_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8(vint64m8_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t ci,
+                                                 size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1(vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2(vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4(vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8(vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t ci,
+                                                  size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_m(vbool64_t vm,
+                                                    vuint64m1_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_m(vbool32_t vm,
+                                                    vuint64m2_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_m(vbool16_t vm,
+                                                    vuint64m4_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_m(vbool8_t vm, vuint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+----

--- a/auto-generated/intrinsic_funcs/21_zvfwbdota16bf_-_bf16_batched_widening_dot_product.adoc
+++ b/auto-generated/intrinsic_funcs/21_zvfwbdota16bf_-_bf16_batched_widening_dot_product.adoc
@@ -1,0 +1,46 @@
+
+=== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[[zvfwbdota16bf-bf16-batched-widening-dot-product]]
+==== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1(vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2(vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4(vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8(vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vbool32_t vm,
+                                                       vfloat32m1_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vbool16_t vm,
+                                                       vfloat32m2_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vbool8_t vm,
+                                                       vfloat32m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vbool4_t vm,
+                                                       vfloat32m8_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t ci, size_t vl);
+----

--- a/auto-generated/intrinsic_funcs/22_zvfqwbdota8f_-_fp8_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/intrinsic_funcs/22_zvfqwbdota8f_-_fp8_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,122 @@
+
+=== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[[zvfqwbdota8f-fp8-batched-quad-widening-dot-product]]
+==== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+----

--- a/auto-generated/intrinsic_funcs/23_zvfbdota32f_-_fp32_batched_dot_product.adoc
+++ b/auto-generated/intrinsic_funcs/23_zvfbdota32f_-_fp32_batched_dot_product.adoc
@@ -1,0 +1,59 @@
+
+=== Zvfbdota32f - FP32 Batched Dot Product
+
+[[zvfbdota32f-fp32-batched-dot-product]]
+==== Zvfbdota32f - FP32 Batched Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfbdota_vv_f32m1(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         unsigned int frm, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, unsigned int frm,
+                                           size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, unsigned int frm,
+                                           size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, unsigned int frm,
+                                           size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, unsigned int frm,
+                                           size_t vl);
+----

--- a/auto-generated/llvm-api-tests/vfbdota.c
+++ b/auto-generated/llvm-api-tests/vfbdota.c
@@ -1,0 +1,100 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfbdota32f \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                       vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                       vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                       vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_m(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                       vl);
+}

--- a/auto-generated/llvm-api-tests/vfqwbdota.c
+++ b/auto-generated/llvm-api-tests/vfqwbdota.c
@@ -1,0 +1,264 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfqwbdota8f \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(vm, vd, vs2, vs1, 0,
+                                                        vl);
+}

--- a/auto-generated/llvm-api-tests/vfwbdota.c
+++ b/auto-generated/llvm-api-tests/vfwbdota.c
@@ -1,0 +1,68 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfwbdota16bf \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1(vfloat32m1_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2(vfloat32m2_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4(vfloat32m4_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8(vfloat32m8_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vbool32_t vm,
+                                                    vfloat32m1_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vbool16_t vm,
+                                                    vfloat32m2_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vbool8_t vm,
+                                                    vfloat32m4_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vbool4_t vm,
+                                                    vfloat32m8_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/llvm-api-tests/vqwbdota.c
+++ b/auto-generated/llvm-api-tests/vqwbdota.c
@@ -1,0 +1,360 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvqwbdota8i \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1(vint32m1_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2(vint32m2_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4(vint32m4_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8(vint32m8_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1(vuint32m1_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2(vuint32m2_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4(vuint32m4_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8(vuint32m8_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_m(vbool32_t vm, vuint32m1_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_m(vbool16_t vm, vuint32m2_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_m(vbool8_t vm, vuint32m4_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_m(vbool4_t vm, vuint32m8_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1(vint64m1_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2(vint64m2_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4(vint64m4_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8(vint64m8_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1(vuint64m1_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2(vuint64m2_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4(vuint64m4_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8(vuint64m8_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_m(vbool64_t vm, vuint64m1_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_m(vbool32_t vm, vuint64m2_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_m(vbool16_t vm, vuint64m4_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_m(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_m(vbool8_t vm, vuint64m8_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_m(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/llvm-overloaded-tests/vfbdota.c
+++ b/auto-generated/llvm-overloaded-tests/vfbdota.c
@@ -1,0 +1,96 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfbdota32f \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}

--- a/auto-generated/llvm-overloaded-tests/vfqwbdota.c
+++ b/auto-generated/llvm-overloaded-tests/vfqwbdota.c
@@ -1,0 +1,248 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfqwbdota8f \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/llvm-overloaded-tests/vfwbdota.c
+++ b/auto-generated/llvm-overloaded-tests/vfwbdota.c
@@ -1,0 +1,68 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfwbdota16bf \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1(vfloat32m1_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2(vfloat32m2_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4(vfloat32m4_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8(vfloat32m8_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vbool32_t vm,
+                                                    vfloat32m1_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vbool16_t vm,
+                                                    vfloat32m2_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vbool8_t vm,
+                                                    vfloat32m4_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vbool4_t vm,
+                                                    vfloat32m8_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/llvm-overloaded-tests/vqwbdota.c
+++ b/auto-generated/llvm-overloaded-tests/vqwbdota.c
@@ -1,0 +1,360 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvqwbdota8i \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1(vint32m1_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2(vint32m2_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4(vint32m4_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8(vint32m8_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1(vuint32m1_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2(vuint32m2_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4(vuint32m4_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8(vuint32m8_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_m(vbool32_t vm, vuint32m1_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_m(vbool16_t vm, vuint32m2_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_m(vbool8_t vm, vuint32m4_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_m(vbool4_t vm, vuint32m8_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1(vint64m1_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2(vint64m2_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4(vint64m4_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8(vint64m8_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1(vuint64m1_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2(vuint64m2_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4(vuint64m4_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8(vuint64m8_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_m(vbool64_t vm, vuint64m1_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_m(vbool32_t vm, vuint64m2_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_m(vbool16_t vm, vuint64m4_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_m(vbool8_t vm, vuint64m8_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/overloaded-api-testing/vfbdota.c
+++ b/auto-generated/overloaded-api-testing/vfbdota.c
@@ -1,0 +1,90 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                   vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_m(vbool32_t vm, vfloat32m1_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_m(vbool16_t vm, vfloat32m2_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_m(vbool8_t vm, vfloat32m4_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_m(vbool4_t vm, vfloat32m8_t vd,
+                                     vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                     size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_m(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_m(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_m(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_m(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}

--- a/auto-generated/overloaded-api-testing/vfqwbdota.c
+++ b/auto-generated/overloaded-api-testing/vfqwbdota.c
@@ -1,0 +1,242 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e4m3m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e4m3m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vfloat32m1_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2(vfloat32m2_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4(vfloat32m4_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8(vfloat32m8_t vd,
+                                                       vfloat8e5m2m8_t vs2,
+                                                       vfloat8e5m2m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e4m3m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e4m3m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_m(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_m(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_m(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_m(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vfloat8e5m2m8_t vs2,
+                                                         vfloat8e5m2m1_t vs1,
+                                                         size_t vl) {
+  return __riscv_vfqwbdota(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/overloaded-api-testing/vfwbdota.c
+++ b/auto-generated/overloaded-api-testing/vfwbdota.c
@@ -1,0 +1,62 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1(vfloat32m1_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2(vfloat32m2_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4(vfloat32m4_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8(vfloat32m8_t vd,
+                                                  vbfloat16m8_t vs2,
+                                                  vbfloat16m1_t vs1,
+                                                  size_t vl) {
+  return __riscv_vfwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_m(vbool32_t vm,
+                                                    vfloat32m1_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_m(vbool16_t vm,
+                                                    vfloat32m2_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_m(vbool8_t vm,
+                                                    vfloat32m4_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_m(vbool4_t vm,
+                                                    vfloat32m8_t vd,
+                                                    vbfloat16m8_t vs2,
+                                                    vbfloat16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vfwbdota(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/overloaded-api-testing/vqwbdota.c
+++ b/auto-generated/overloaded-api-testing/vqwbdota.c
@@ -1,0 +1,354 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2(vint32m2_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4(vint32m4_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8(vint32m8_t vd, vint8m8_t vs2,
+                                            vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1(vint32m1_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2(vint32m2_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4(vint32m4_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8(vint32m8_t vd, vuint8m8_t vs2,
+                                            vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1(vuint32m1_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2(vuint32m2_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4(vuint32m4_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8(vuint32m8_t vd, vuint8m8_t vs2,
+                                             vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vint8m8_t vs2, vuint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_m(vbool32_t vm, vint32m1_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_m(vbool16_t vm, vint32m2_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_m(vbool8_t vm, vint32m4_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_m(vbool4_t vm, vint32m8_t vd,
+                                              vuint8m8_t vs2, vint8m1_t vs1,
+                                              size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_m(vbool32_t vm, vuint32m1_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_m(vbool16_t vm, vuint32m2_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_m(vbool8_t vm, vuint32m4_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_m(vbool4_t vm, vuint32m8_t vd,
+                                               vuint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1(vint64m1_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2(vint64m2_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4(vint64m4_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8(vint64m8_t vd, vint16m8_t vs2,
+                                              vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1(vint64m1_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2(vint64m2_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4(vint64m4_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8(vint64m8_t vd, vuint16m8_t vs2,
+                                              vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1(vuint64m1_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2(vuint64m2_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4(vuint64m4_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8(vuint64m8_t vd, vuint16m8_t vs2,
+                                               vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vint16m8_t vs2, vuint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_m(vbool64_t vm, vint64m1_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_m(vbool32_t vm, vint64m2_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_m(vbool16_t vm, vint64m4_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_m(vbool8_t vm, vint64m8_t vd,
+                                                vuint16m8_t vs2, vint16m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_m(vbool64_t vm, vuint64m1_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_m(vbool32_t vm, vuint64m2_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_m(vbool16_t vm, vuint64m4_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_m(vbool8_t vm, vuint64m8_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs.adoc
@@ -42821,3 +42821,318 @@ vfloat32m1_t __riscv_vfqwdota(vbool2_t vm, vfloat32m1_t vd, vfloat8e5m2m4_t vs2,
 vfloat32m1_t __riscv_vfqwdota(vbool1_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2,
                               vfloat8e5m2m8_t vs1, size_t vl);
 ----
+
+=== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[[overloaded-zvqwbdota8i-8-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint32m1_t __riscv_vqwbdota(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota(vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota(vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                             size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota(vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                             size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota(vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                             size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota(vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                             size_t ci, size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                            vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                            vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                            vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                            vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2,
+                             vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2,
+                             vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2,
+                             vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+                             vuint8m1_t vs1, size_t ci, size_t vl);
+----
+
+=== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[[overloaded-zvqwbdota16i-16-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint64m1_t __riscv_vqwbdota(vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota(vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota(vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota(vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1,
+                             size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota(vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1,
+                             size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota(vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1,
+                             size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota(vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1,
+                             size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                            vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                            vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                            vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                            vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2,
+                             vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2,
+                             vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2,
+                             vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2,
+                             vuint16m1_t vs1, size_t ci, size_t vl);
+----
+
+=== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[[overloaded-zvfwbdota16bf-bf16-batched-widening-dot-product]]
+==== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfwbdota(vfloat32m1_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota(vfloat32m2_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota(vfloat32m4_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota(vfloat32m8_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+----
+
+=== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[[overloaded-zvfqwbdota8f-fp8-batched-quad-widening-dot-product]]
+==== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfqwbdota(vfloat32m1_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vfloat32m2_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vfloat32m4_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vfloat32m8_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vfloat32m1_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vfloat32m2_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vfloat32m4_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vfloat32m8_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vfloat32m1_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vfloat32m2_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vfloat32m4_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vfloat32m8_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vfloat32m1_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vfloat32m2_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vfloat32m4_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vfloat32m8_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota(vbool32_t vm, vfloat32m1_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vbool16_t vm, vfloat32m2_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vbool8_t vm, vfloat32m4_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vbool4_t vm, vfloat32m8_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vbool32_t vm, vfloat32m1_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vbool16_t vm, vfloat32m2_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vbool8_t vm, vfloat32m4_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vbool4_t vm, vfloat32m8_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vbool32_t vm, vfloat32m1_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vbool16_t vm, vfloat32m2_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vbool8_t vm, vfloat32m4_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vbool4_t vm, vfloat32m8_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vbool32_t vm, vfloat32m1_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vbool16_t vm, vfloat32m2_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vbool8_t vm, vfloat32m4_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vbool4_t vm, vfloat32m8_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+----
+
+=== Zvfbdota32f - FP32 Batched Dot Product
+
+[[overloaded-zvfbdota32f-fp32-batched-dot-product]]
+==== Zvfbdota32f - FP32 Batched Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfbdota(vfloat32m1_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota(vfloat32m2_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota(vfloat32m4_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota(vfloat32m8_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfbdota(vfloat32m1_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m2_t __riscv_vfbdota(vfloat32m2_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m4_t __riscv_vfbdota(vfloat32m4_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m8_t __riscv_vfbdota(vfloat32m8_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m2_t __riscv_vfbdota(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m4_t __riscv_vfbdota(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m8_t __riscv_vfbdota(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+----

--- a/auto-generated/overloaded_intrinsic_funcs/19_zvqwbdota8i_-_8-bit_integer_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/19_zvqwbdota8i_-_8-bit_integer_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,74 @@
+
+=== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[[overloaded-zvqwbdota8i-8-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint32m1_t __riscv_vqwbdota(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota(vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                            size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota(vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                             size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota(vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                             size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota(vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                             size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota(vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                             size_t ci, size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                            vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                            vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                            vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                            vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+                            vint8m1_t vs1, size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2,
+                             vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2,
+                             vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2,
+                             vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+                             vuint8m1_t vs1, size_t ci, size_t vl);
+----

--- a/auto-generated/overloaded_intrinsic_funcs/20_zvqwbdota16i_-_16-bit_integer_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/20_zvqwbdota16i_-_16-bit_integer_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,74 @@
+
+=== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[[overloaded-zvqwbdota16i-16-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint64m1_t __riscv_vqwbdota(vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota(vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota(vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                            size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota(vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1,
+                             size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota(vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1,
+                             size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota(vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1,
+                             size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota(vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1,
+                             size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                            vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                            vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                            vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                            vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2,
+                            vint16m1_t vs1, size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2,
+                             vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2,
+                             vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2,
+                             vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2,
+                             vuint16m1_t vs1, size_t ci, size_t vl);
+----

--- a/auto-generated/overloaded_intrinsic_funcs/21_zvfwbdota16bf_-_bf16_batched_widening_dot_product.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/21_zvfwbdota16bf_-_bf16_batched_widening_dot_product.adoc
@@ -1,0 +1,26 @@
+
+=== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[[overloaded-zvfwbdota16bf-bf16-batched-widening-dot-product]]
+==== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfwbdota(vfloat32m1_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota(vfloat32m2_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota(vfloat32m4_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota(vfloat32m8_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2,
+                              vbfloat16m1_t vs1, size_t ci, size_t vl);
+----

--- a/auto-generated/overloaded_intrinsic_funcs/22_zvfqwbdota8f_-_fp8_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/22_zvfqwbdota8f_-_fp8_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,90 @@
+
+=== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[[overloaded-zvfqwbdota8f-fp8-batched-quad-widening-dot-product]]
+==== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfqwbdota(vfloat32m1_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vfloat32m2_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vfloat32m4_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vfloat32m8_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vfloat32m1_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vfloat32m2_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vfloat32m4_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vfloat32m8_t vd, vfloat8e4m3m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vfloat32m1_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vfloat32m2_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vfloat32m4_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vfloat32m8_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vfloat32m1_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vfloat32m2_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vfloat32m4_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vfloat32m8_t vd, vfloat8e5m2m8_t vs2,
+                               vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota(vbool32_t vm, vfloat32m1_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vbool16_t vm, vfloat32m2_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vbool8_t vm, vfloat32m4_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vbool4_t vm, vfloat32m8_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vbool32_t vm, vfloat32m1_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vbool16_t vm, vfloat32m2_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vbool8_t vm, vfloat32m4_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vbool4_t vm, vfloat32m8_t vd,
+                               vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vbool32_t vm, vfloat32m1_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vbool16_t vm, vfloat32m2_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vbool8_t vm, vfloat32m4_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vbool4_t vm, vfloat32m8_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota(vbool32_t vm, vfloat32m1_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota(vbool16_t vm, vfloat32m2_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota(vbool8_t vm, vfloat32m4_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota(vbool4_t vm, vfloat32m8_t vd,
+                               vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                               size_t ci, size_t vl);
+----

--- a/auto-generated/overloaded_intrinsic_funcs/23_zvfbdota32f_-_fp32_batched_dot_product.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/23_zvfbdota32f_-_fp32_batched_dot_product.adoc
@@ -1,0 +1,51 @@
+
+=== Zvfbdota32f - FP32 Batched Dot Product
+
+[[overloaded-zvfbdota32f-fp32-batched-dot-product]]
+==== Zvfbdota32f - FP32 Batched Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfbdota(vfloat32m1_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota(vfloat32m2_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota(vfloat32m4_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota(vfloat32m8_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfbdota(vfloat32m1_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m2_t __riscv_vfbdota(vfloat32m2_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m4_t __riscv_vfbdota(vfloat32m4_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m8_t __riscv_vfbdota(vfloat32m8_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m2_t __riscv_vfbdota(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m4_t __riscv_vfbdota(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+vfloat32m8_t __riscv_vfbdota(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                             vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                             size_t vl);
+----

--- a/auto-generated/policy_funcs/api-testing/vfbdota.c
+++ b/auto-generated/policy_funcs/api-testing/vfbdota.c
@@ -1,0 +1,198 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                         vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                         vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                         vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                         vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                          vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                          vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                          vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                          vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                        vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                        vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                        vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                        vl);
+}

--- a/auto-generated/policy_funcs/api-testing/vfqwbdota.c
+++ b/auto-generated/policy_funcs/api-testing/vfqwbdota.c
@@ -1,0 +1,546 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}

--- a/auto-generated/policy_funcs/api-testing/vfwbdota.c
+++ b/auto-generated/policy_funcs/api-testing/vfwbdota.c
@@ -1,0 +1,126 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vbool32_t vm,
+                                                      vfloat32m1_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vbool16_t vm,
+                                                      vfloat32m2_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vbool8_t vm,
+                                                      vfloat32m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vbool4_t vm,
+                                                      vfloat32m8_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vbool32_t vm,
+                                                       vfloat32m1_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vbool16_t vm,
+                                                       vfloat32m2_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vbool8_t vm,
+                                                       vfloat32m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vbool4_t vm,
+                                                       vfloat32m8_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vbool32_t vm,
+                                                     vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vbool16_t vm,
+                                                     vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vbool8_t vm,
+                                                     vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vbool4_t vm,
+                                                     vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/api-testing/vqwbdota.c
+++ b/auto-generated/policy_funcs/api-testing/vqwbdota.c
@@ -1,0 +1,740 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vint32m1_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vint32m2_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vint32m4_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vuint32m1_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vuint32m2_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vuint32m4_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vint64m1_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vint64m2_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vint64m4_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vint64m8_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vbool64_t vm, vuint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vbool32_t vm, vuint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vbool16_t vm, vuint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vbool8_t vm, vuint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(
+    vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(
+    vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(
+    vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vbool8_t vm, vuint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vbool64_t vm, vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vbool32_t vm, vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vbool16_t vm, vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vbool8_t vm, vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/gnu-api-tests/vfbdota.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfbdota.c
@@ -1,0 +1,133 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tu(vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tu(vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tu(vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfbdota\.[ivxfswum.]+\s+} 32 } } */

--- a/auto-generated/policy_funcs/gnu-api-tests/vfqwbdota.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfqwbdota.c
@@ -1,0 +1,261 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfqwbdota\.[ivxfswum.]+\s+} 64 } } */

--- a/auto-generated/policy_funcs/gnu-api-tests/vfwbdota.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfwbdota.c
@@ -1,0 +1,69 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfwbdota\.[ivxfswum.]+\s+} 16 } } */

--- a/auto-generated/policy_funcs/gnu-api-tests/vqwbdota.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vqwbdota.c
@@ -1,0 +1,517 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vqwbdota\.[ivxfswum.]+\s+} 128 } } */

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfbdota.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfbdota.c
@@ -1,0 +1,133 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tu(vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tu(vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tu(vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2, vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfbdota\.[ivxfswum.]+\s+} 32 } } */

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfqwbdota.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfqwbdota.c
@@ -1,0 +1,261 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfqwbdota\.[ivxfswum.]+\s+} 64 } } */

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfwbdota.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfwbdota.c
@@ -1,0 +1,69 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vbool32_t vm, vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vbool16_t vm, vfloat32m2_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vbool8_t vm, vfloat32m4_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vbool4_t vm, vfloat32m8_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfwbdota\.[ivxfswum.]+\s+} 16 } } */

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vqwbdota.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vqwbdota.c
@@ -1,0 +1,517 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv_zvfh -mabi=lp64d -Wno-psabi -O3 -fno-schedule-insns -fno-schedule-insns2" } */
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+/* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vqwbdota\.[ivxfswum.]+\s+} 128 } } */

--- a/auto-generated/policy_funcs/intrinsic_funcs.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs.adoc
@@ -98188,3 +98188,965 @@ __riscv_vfqwdota_vv_f8e5m2m8_f8e5m2m8_f32m1_tum(vbool1_t vm, vfloat32m1_t vd,
                                                 vfloat8e5m2m8_t vs2,
                                                 vfloat8e5m2m8_t vs1, size_t vl);
 ----
+
+=== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[[policy-variant-zvqwbdota8i-8-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vint32m1_t vd, vuint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vint32m2_t vd, vuint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vint32m4_t vd, vuint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vuint32m1_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vuint32m2_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vuint32m4_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vuint32m8_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                   vint8m8_t vs2, vint8m1_t vs1,
+                                                   size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                   vint8m8_t vs2, vint8m1_t vs1,
+                                                   size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                   vint8m8_t vs2, vint8m1_t vs1,
+                                                   size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                   vint8m8_t vs2, vint8m1_t vs1,
+                                                   size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                   vint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                   vint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                   vint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                   vint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vbool32_t vm,
+                                                    vuint32m1_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vbool16_t vm,
+                                                    vuint32m2_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                    vint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                    vint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                    vint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                    vint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                    vint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                    vint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                    vint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                    vint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vbool32_t vm,
+                                                     vuint32m1_t vd,
+                                                     vuint8m8_t vs2,
+                                                     vuint8m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vbool16_t vm,
+                                                     vuint32m2_t vd,
+                                                     vuint8m8_t vs2,
+                                                     vuint8m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vbool8_t vm,
+                                                     vuint32m4_t vd,
+                                                     vuint8m8_t vs2,
+                                                     vuint8m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vbool4_t vm,
+                                                     vuint32m8_t vd,
+                                                     vuint8m8_t vs2,
+                                                     vuint8m1_t vs1, size_t ci,
+                                                     size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                                  vint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                                  vint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                                  vint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                                  vint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                                  vint8m8_t vs2, vuint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                                  vint8m8_t vs2, vuint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                                  vint8m8_t vs2, vuint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                                  vint8m8_t vs2, vuint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                                  vuint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                                  vuint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                                  vuint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                                  vuint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+----
+
+=== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[[policy-variant-zvqwbdota16i-16-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vint64m1_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vint64m2_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vint64m4_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vint64m8_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vint64m1_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vint64m2_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vint64m4_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vint64m8_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vint64m1_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vint64m2_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vint64m4_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vuint64m1_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vuint64m2_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vuint64m4_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vuint64m8_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vbool64_t vm,
+                                                     vint64m1_t vd,
+                                                     vint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vbool32_t vm,
+                                                     vint64m2_t vd,
+                                                     vint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vbool16_t vm,
+                                                     vint64m4_t vd,
+                                                     vint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                     vint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vbool64_t vm,
+                                                     vint64m1_t vd,
+                                                     vint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vbool32_t vm,
+                                                     vint64m2_t vd,
+                                                     vint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vbool16_t vm,
+                                                     vint64m4_t vd,
+                                                     vint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                     vint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vbool64_t vm,
+                                                     vint64m1_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vbool32_t vm,
+                                                     vint64m2_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vbool16_t vm,
+                                                     vint64m4_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vbool64_t vm,
+                                                      vuint64m1_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vbool32_t vm,
+                                                      vuint64m2_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vbool16_t vm,
+                                                      vuint64m4_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vbool8_t vm,
+                                                      vuint64m8_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vbool64_t vm,
+                                                      vint64m1_t vd,
+                                                      vint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vbool32_t vm,
+                                                      vint64m2_t vd,
+                                                      vint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vbool16_t vm,
+                                                      vint64m4_t vd,
+                                                      vint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vbool8_t vm,
+                                                      vint64m8_t vd,
+                                                      vint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vbool64_t vm,
+                                                      vint64m1_t vd,
+                                                      vint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vbool32_t vm,
+                                                      vint64m2_t vd,
+                                                      vint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vbool16_t vm,
+                                                      vint64m4_t vd,
+                                                      vint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vbool8_t vm,
+                                                      vint64m8_t vd,
+                                                      vint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vbool64_t vm,
+                                                      vint64m1_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vbool32_t vm,
+                                                      vint64m2_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vbool16_t vm,
+                                                      vint64m4_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vbool8_t vm,
+                                                      vint64m8_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(vbool64_t vm,
+                                                       vuint64m1_t vd,
+                                                       vuint16m8_t vs2,
+                                                       vuint16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(vbool32_t vm,
+                                                       vuint64m2_t vd,
+                                                       vuint16m8_t vs2,
+                                                       vuint16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(vbool16_t vm,
+                                                       vuint64m4_t vd,
+                                                       vuint16m8_t vs2,
+                                                       vuint16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vbool8_t vm,
+                                                       vuint64m8_t vd,
+                                                       vuint16m8_t vs2,
+                                                       vuint16m1_t vs1,
+                                                       size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vbool64_t vm,
+                                                     vuint64m1_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vbool32_t vm,
+                                                     vuint64m2_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vbool16_t vm,
+                                                     vuint64m4_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vbool8_t vm,
+                                                     vuint64m8_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+----
+
+=== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[[policy-variant-zvfwbdota16bf-bf16-batched-widening-dot-product]]
+==== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vfloat32m1_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vfloat32m2_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vfloat32m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vfloat32m8_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         vbfloat16m1_t vs1,
+                                                         size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         vbfloat16m1_t vs1,
+                                                         size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         vbfloat16m1_t vs1,
+                                                         size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         vbfloat16m1_t vs1,
+                                                         size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          vbfloat16m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          vbfloat16m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          vbfloat16m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          vbfloat16m1_t vs1,
+                                                          size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vbool32_t vm,
+                                                        vfloat32m1_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vbool16_t vm,
+                                                        vfloat32m2_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vbool8_t vm,
+                                                        vfloat32m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vbool4_t vm,
+                                                        vfloat32m8_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+----
+
+=== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[[policy-variant-zvfqwbdota8f-fp8-batched-quad-widening-dot-product]]
+==== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(
+    vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(
+    vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(
+    vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(
+    vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(
+    vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(
+    vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(
+    vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(
+    vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(
+    vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(
+    vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(
+    vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(
+    vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(
+    vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(
+    vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(
+    vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(
+    vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+----
+
+=== Zvfbdota32f - FP32 Batched Dot Product
+
+[[policy-variant-zvfbdota32f-fp32-batched-dot-product]]
+==== Zvfbdota32f - FP32 Batched Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                            vfloat32m1_t vs1, size_t ci,
+                                            unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                            vfloat32m1_t vs1, size_t ci,
+                                            unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                            vfloat32m1_t vs1, size_t ci,
+                                            unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                            vfloat32m1_t vs1, size_t ci,
+                                            unsigned int frm, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
+                                             vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                             size_t ci, unsigned int frm,
+                                             size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
+                                             vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                             size_t ci, unsigned int frm,
+                                             size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
+                                             vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                             size_t ci, unsigned int frm,
+                                             size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
+                                             vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                             size_t ci, unsigned int frm,
+                                             size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                              vfloat32m8_t vs2,
+                                              vfloat32m1_t vs1, size_t ci,
+                                              unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                              vfloat32m8_t vs2,
+                                              vfloat32m1_t vs1, size_t ci,
+                                              unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                              vfloat32m8_t vs2,
+                                              vfloat32m1_t vs1, size_t ci,
+                                              unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                              vfloat32m8_t vs2,
+                                              vfloat32m1_t vs1, size_t ci,
+                                              unsigned int frm, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
+                                            vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                            size_t ci, unsigned int frm,
+                                            size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
+                                            vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                            size_t ci, unsigned int frm,
+                                            size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
+                                            vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                            size_t ci, unsigned int frm,
+                                            size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
+                                            vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                            size_t ci, unsigned int frm,
+                                            size_t vl);
+----

--- a/auto-generated/policy_funcs/intrinsic_funcs/19_zvqwbdota8i_-_8-bit_integer_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/19_zvqwbdota8i_-_8-bit_integer_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,246 @@
+
+=== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[[policy-variant-zvqwbdota8i-8-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vint32m1_t vd, vuint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vint32m2_t vd, vuint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vint32m4_t vd, vuint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2,
+                                                  vint8m1_t vs1, size_t ci,
+                                                  size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vuint32m1_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vuint32m2_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vuint32m4_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vuint32m8_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                   vint8m8_t vs2, vint8m1_t vs1,
+                                                   size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                   vint8m8_t vs2, vint8m1_t vs1,
+                                                   size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                   vint8m8_t vs2, vint8m1_t vs1,
+                                                   size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                   vint8m8_t vs2, vint8m1_t vs1,
+                                                   size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                   vint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                   vint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                   vint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                   vint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vbool32_t vm,
+                                                    vuint32m1_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vbool16_t vm,
+                                                    vuint32m2_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                    vint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                    vint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                    vint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                    vint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                    vint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                    vint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                    vint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                    vint8m8_t vs2,
+                                                    vuint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                    vuint8m8_t vs2,
+                                                    vint8m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vbool32_t vm,
+                                                     vuint32m1_t vd,
+                                                     vuint8m8_t vs2,
+                                                     vuint8m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vbool16_t vm,
+                                                     vuint32m2_t vd,
+                                                     vuint8m8_t vs2,
+                                                     vuint8m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vbool8_t vm,
+                                                     vuint32m4_t vd,
+                                                     vuint8m8_t vs2,
+                                                     vuint8m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vbool4_t vm,
+                                                     vuint32m8_t vd,
+                                                     vuint8m8_t vs2,
+                                                     vuint8m1_t vs1, size_t ci,
+                                                     size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                                  vint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                                  vint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                                  vint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                                  vint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                                  vint8m8_t vs2, vuint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                                  vint8m8_t vs2, vuint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                                  vint8m8_t vs2, vuint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                                  vint8m8_t vs2, vuint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                                  vuint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                                  vuint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                                  vuint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                                  vuint8m8_t vs2, vint8m1_t vs1,
+                                                  size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m2_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m4_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+vuint32m8_t __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
+                                                   vuint8m8_t vs2,
+                                                   vuint8m1_t vs1, size_t ci,
+                                                   size_t vl);
+----

--- a/auto-generated/policy_funcs/intrinsic_funcs/20_zvqwbdota16i_-_16-bit_integer_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/20_zvqwbdota16i_-_16-bit_integer_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,301 @@
+
+=== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[[policy-variant-zvqwbdota16i-16-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vint64m1_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vint64m2_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vint64m4_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vint64m8_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vint64m1_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vint64m2_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vint64m4_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vint64m8_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vint64m1_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vint64m2_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vint64m4_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vuint64m1_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vuint64m2_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vuint64m4_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vuint64m8_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vbool64_t vm,
+                                                     vint64m1_t vd,
+                                                     vint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vbool32_t vm,
+                                                     vint64m2_t vd,
+                                                     vint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vbool16_t vm,
+                                                     vint64m4_t vd,
+                                                     vint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                     vint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vbool64_t vm,
+                                                     vint64m1_t vd,
+                                                     vint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vbool32_t vm,
+                                                     vint64m2_t vd,
+                                                     vint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vbool16_t vm,
+                                                     vint64m4_t vd,
+                                                     vint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                     vint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vbool64_t vm,
+                                                     vint64m1_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vbool32_t vm,
+                                                     vint64m2_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vbool16_t vm,
+                                                     vint64m4_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vbool64_t vm,
+                                                      vuint64m1_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vbool32_t vm,
+                                                      vuint64m2_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vbool16_t vm,
+                                                      vuint64m4_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vbool8_t vm,
+                                                      vuint64m8_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vbool64_t vm,
+                                                      vint64m1_t vd,
+                                                      vint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vbool32_t vm,
+                                                      vint64m2_t vd,
+                                                      vint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vbool16_t vm,
+                                                      vint64m4_t vd,
+                                                      vint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vbool8_t vm,
+                                                      vint64m8_t vd,
+                                                      vint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vbool64_t vm,
+                                                      vint64m1_t vd,
+                                                      vint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vbool32_t vm,
+                                                      vint64m2_t vd,
+                                                      vint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vbool16_t vm,
+                                                      vint64m4_t vd,
+                                                      vint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vbool8_t vm,
+                                                      vint64m8_t vd,
+                                                      vint16m8_t vs2,
+                                                      vuint16m1_t vs1,
+                                                      size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vbool64_t vm,
+                                                      vint64m1_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vbool32_t vm,
+                                                      vint64m2_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vbool16_t vm,
+                                                      vint64m4_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vbool8_t vm,
+                                                      vint64m8_t vd,
+                                                      vuint16m8_t vs2,
+                                                      vint16m1_t vs1, size_t ci,
+                                                      size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(vbool64_t vm,
+                                                       vuint64m1_t vd,
+                                                       vuint16m8_t vs2,
+                                                       vuint16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(vbool32_t vm,
+                                                       vuint64m2_t vd,
+                                                       vuint16m8_t vs2,
+                                                       vuint16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(vbool16_t vm,
+                                                       vuint64m4_t vd,
+                                                       vuint16m8_t vs2,
+                                                       vuint16m1_t vs1,
+                                                       size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vbool8_t vm,
+                                                       vuint64m8_t vd,
+                                                       vuint16m8_t vs2,
+                                                       vuint16m1_t vs1,
+                                                       size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                    vint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                    vint16m8_t vs2,
+                                                    vuint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m1_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m2_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m4_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vint64m8_t __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vint16m1_t vs1, size_t ci,
+                                                    size_t vl);
+vuint64m1_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vbool64_t vm,
+                                                     vuint64m1_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m2_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vbool32_t vm,
+                                                     vuint64m2_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m4_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vbool16_t vm,
+                                                     vuint64m4_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+vuint64m8_t __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vbool8_t vm,
+                                                     vuint64m8_t vd,
+                                                     vuint16m8_t vs2,
+                                                     vuint16m1_t vs1, size_t ci,
+                                                     size_t vl);
+----

--- a/auto-generated/policy_funcs/intrinsic_funcs/21_zvfwbdota16bf_-_bf16_batched_widening_dot_product.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/21_zvfwbdota16bf_-_bf16_batched_widening_dot_product.adoc
@@ -1,0 +1,88 @@
+
+=== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[[policy-variant-zvfwbdota16bf-bf16-batched-widening-dot-product]]
+==== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vfloat32m1_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vfloat32m2_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vfloat32m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vfloat32m8_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vbool32_t vm,
+                                                         vfloat32m1_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         vbfloat16m1_t vs1,
+                                                         size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vbool16_t vm,
+                                                         vfloat32m2_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         vbfloat16m1_t vs1,
+                                                         size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vbool8_t vm,
+                                                         vfloat32m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         vbfloat16m1_t vs1,
+                                                         size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vbool4_t vm,
+                                                         vfloat32m8_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         vbfloat16m1_t vs1,
+                                                         size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          vbfloat16m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          vbfloat16m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          vbfloat16m1_t vs1,
+                                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          vbfloat16m1_t vs1,
+                                                          size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vbool32_t vm,
+                                                        vfloat32m1_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vbool16_t vm,
+                                                        vfloat32m2_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vbool8_t vm,
+                                                        vfloat32m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vbool4_t vm,
+                                                        vfloat32m8_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        vbfloat16m1_t vs1,
+                                                        size_t ci, size_t vl);
+----

--- a/auto-generated/policy_funcs/intrinsic_funcs/22_zvfqwbdota8f_-_fp8_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/22_zvfqwbdota8f_-_fp8_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,204 @@
+
+=== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[[policy-variant-zvfqwbdota8f-fp8-batched-quad-widening-dot-product]]
+==== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(
+    vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(
+    vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(
+    vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(
+    vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(
+    vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(
+    vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(
+    vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(
+    vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(
+    vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(
+    vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(
+    vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(
+    vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(
+    vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(
+    vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(
+    vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(
+    vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci,
+    size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(
+    vbool32_t vm, vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(
+    vbool16_t vm, vfloat32m2_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(
+    vbool8_t vm, vfloat32m4_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(
+    vbool4_t vm, vfloat32m8_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+    size_t ci, size_t vl);
+----

--- a/auto-generated/policy_funcs/intrinsic_funcs/23_zvfbdota32f_-_fp32_batched_dot_product.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/23_zvfbdota32f_-_fp32_batched_dot_product.adoc
@@ -1,0 +1,123 @@
+
+=== Zvfbdota32f - FP32 Batched Dot Product
+
+[[policy-variant-zvfbdota32f-fp32-batched-dot-product]]
+==== Zvfbdota32f - FP32 Batched Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t ci,
+                                         size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                            vfloat32m1_t vs1, size_t ci,
+                                            unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                            vfloat32m1_t vs1, size_t ci,
+                                            unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                            vfloat32m1_t vs1, size_t ci,
+                                            unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                            vfloat32m1_t vs1, size_t ci,
+                                            unsigned int frm, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
+                                             vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                             size_t ci, unsigned int frm,
+                                             size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
+                                             vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                             size_t ci, unsigned int frm,
+                                             size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
+                                             vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                             size_t ci, unsigned int frm,
+                                             size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
+                                             vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                             size_t ci, unsigned int frm,
+                                             size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                              vfloat32m8_t vs2,
+                                              vfloat32m1_t vs1, size_t ci,
+                                              unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                              vfloat32m8_t vs2,
+                                              vfloat32m1_t vs1, size_t ci,
+                                              unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                              vfloat32m8_t vs2,
+                                              vfloat32m1_t vs1, size_t ci,
+                                              unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                              vfloat32m8_t vs2,
+                                              vfloat32m1_t vs1, size_t ci,
+                                              unsigned int frm, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
+                                            vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                            size_t ci, unsigned int frm,
+                                            size_t vl);
+vfloat32m2_t __riscv_vfbdota_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
+                                            vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                            size_t ci, unsigned int frm,
+                                            size_t vl);
+vfloat32m4_t __riscv_vfbdota_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
+                                            vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                            size_t ci, unsigned int frm,
+                                            size_t vl);
+vfloat32m8_t __riscv_vfbdota_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
+                                            vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                            size_t ci, unsigned int frm,
+                                            size_t vl);
+----

--- a/auto-generated/policy_funcs/llvm-api-tests/vfbdota.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfbdota.c
@@ -1,0 +1,204 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfbdota32f \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                         vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                         vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                         vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                         vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                          vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                          vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                          vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                          vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_vv_f32m1_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                        vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_vv_f32m2_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                        vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_vv_f32m4_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                        vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_vv_f32m8_rm_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE,
+                                        vl);
+}

--- a/auto-generated/policy_funcs/llvm-api-tests/vfqwbdota.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfqwbdota.c
@@ -1,0 +1,552 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfqwbdota8f \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(vm, vd, vs2, vs1, 0,
+                                                          vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(vm, vd, vs2, vs1, 0,
+                                                           vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(vm, vd, vs2, vs1, 0,
+                                                         vl);
+}

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwbdota.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwbdota.c
@@ -1,0 +1,132 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfwbdota16bf \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vbool32_t vm,
+                                                      vfloat32m1_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vbool16_t vm,
+                                                      vfloat32m2_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vbool8_t vm,
+                                                      vfloat32m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vbool4_t vm,
+                                                      vfloat32m8_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vbool32_t vm,
+                                                       vfloat32m1_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vbool16_t vm,
+                                                       vfloat32m2_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vbool8_t vm,
+                                                       vfloat32m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vbool4_t vm,
+                                                       vfloat32m8_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vbool32_t vm,
+                                                     vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vbool16_t vm,
+                                                     vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vbool8_t vm,
+                                                     vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vbool4_t vm,
+                                                     vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/llvm-api-tests/vqwbdota.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vqwbdota.c
@@ -1,0 +1,746 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvqwbdota8i \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vint32m1_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vint32m2_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vint32m4_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vuint32m1_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vuint32m2_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vuint32m4_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vint64m1_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vint64m2_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vint64m4_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vint64m8_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vbool64_t vm, vuint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vbool32_t vm, vuint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vbool16_t vm, vuint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vbool8_t vm, vuint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(
+    vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(
+    vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(
+    vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vbool8_t vm, vuint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vbool64_t vm, vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vbool32_t vm, vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vbool16_t vm, vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vbool8_t vm, vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfbdota.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfbdota.c
@@ -1,0 +1,192 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfbdota32f \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfqwbdota.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfqwbdota.c
@@ -1,0 +1,504 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfqwbdota8f \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwbdota.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwbdota.c
@@ -1,0 +1,132 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvfwbdota16bf \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vbool32_t vm,
+                                                      vfloat32m1_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vbool16_t vm,
+                                                      vfloat32m2_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vbool8_t vm,
+                                                      vfloat32m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vbool4_t vm,
+                                                      vfloat32m8_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vbool32_t vm,
+                                                       vfloat32m1_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vbool16_t vm,
+                                                       vfloat32m2_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vbool8_t vm,
+                                                       vfloat32m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vbool4_t vm,
+                                                       vfloat32m8_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vbool32_t vm,
+                                                     vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vbool16_t vm,
+                                                     vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vbool8_t vm,
+                                                     vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vbool4_t vm,
+                                                     vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vqwbdota.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vqwbdota.c
@@ -1,0 +1,746 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 -disable-O0-optnone \
+// RUN:   -target-feature +zvqwbdota8i \
+// RUN:   -target-feature +experimental \
+// RUN:   -emit-llvm %s -o - | opt -S -passes=mem2reg | \
+// RUN:   FileCheck --check-prefix=CHECK-RV64 %s
+
+#include <riscv_vector.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vint32m1_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vint32m2_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vint32m4_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vuint32m1_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vuint32m2_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vuint32m4_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vint64m1_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vint64m2_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vint64m4_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vint64m8_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vbool64_t vm, vuint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vbool32_t vm, vuint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vbool16_t vm, vuint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vbool8_t vm, vuint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(
+    vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(
+    vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(
+    vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vbool8_t vm, vuint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vbool64_t vm, vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vbool32_t vm, vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vbool16_t vm, vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vbool8_t vm, vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfbdota.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfbdota.c
@@ -1,0 +1,186 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                      vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tum(vbool32_t vm, vfloat32m1_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tum(vbool16_t vm, vfloat32m2_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tum(vbool8_t vm, vfloat32m4_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tum(vbool4_t vm, vfloat32m8_t vd,
+                                       vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                       size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                        vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                        size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_mu(vbool32_t vm, vfloat32m1_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_mu(vbool16_t vm, vfloat32m2_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_mu(vbool8_t vm, vfloat32m4_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_mu(vbool4_t vm, vfloat32m8_t vd,
+                                      vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                      size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                         vfloat32m1_t vs1, size_t vl) {
+  return __riscv_vfbdota_tu(vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tum(vbool32_t vm, vfloat32m1_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tum(vbool16_t vm, vfloat32m2_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tum(vbool8_t vm, vfloat32m4_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tum(vbool4_t vm, vfloat32m8_t vd,
+                                          vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                          size_t vl) {
+  return __riscv_vfbdota_tum(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                           vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                           size_t vl) {
+  return __riscv_vfbdota_tumu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m1_t test_vfbdota_vv_f32m1_rm_mu(vbool32_t vm, vfloat32m1_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m2_t test_vfbdota_vv_f32m2_rm_mu(vbool16_t vm, vfloat32m2_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m4_t test_vfbdota_vv_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}
+
+vfloat32m8_t test_vfbdota_vv_f32m8_rm_mu(vbool4_t vm, vfloat32m8_t vd,
+                                         vfloat32m8_t vs2, vfloat32m1_t vs1,
+                                         size_t vl) {
+  return __riscv_vfbdota_mu(vm, vd, vs2, vs1, 0, __RISCV_FRM_RNE, vl);
+}

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfqwbdota.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfqwbdota.c
@@ -1,0 +1,498 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tu(vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tu(vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tu(vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tu(vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e4m3m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e4m3m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tum(vbool32_t vm,
+                                                           vfloat32m1_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tum(vbool16_t vm,
+                                                           vfloat32m2_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tum(vbool8_t vm,
+                                                           vfloat32m4_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tum(vbool4_t vm,
+                                                           vfloat32m8_t vd,
+                                                           vfloat8e5m2m8_t vs2,
+                                                           vfloat8e5m2m1_t vs1,
+                                                           size_t vl) {
+  return __riscv_vfqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e4m3m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e4m3m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_tumu(vbool32_t vm,
+                                                            vfloat32m1_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_tumu(vbool16_t vm,
+                                                            vfloat32m2_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_tumu(vbool8_t vm,
+                                                            vfloat32m4_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_tumu(vbool4_t vm,
+                                                            vfloat32m8_t vd,
+                                                            vfloat8e5m2m8_t vs2,
+                                                            vfloat8e5m2m1_t vs1,
+                                                            size_t vl) {
+  return __riscv_vfqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e4m3m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e4m3m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1_mu(vbool32_t vm,
+                                                          vfloat32m1_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m2_mu(vbool16_t vm,
+                                                          vfloat32m2_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m4_mu(vbool8_t vm,
+                                                          vfloat32m4_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m8_mu(vbool4_t vm,
+                                                          vfloat32m8_t vd,
+                                                          vfloat8e5m2m8_t vs2,
+                                                          vfloat8e5m2m1_t vs1,
+                                                          size_t vl) {
+  return __riscv_vfqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfwbdota.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfwbdota.c
@@ -1,0 +1,126 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tu(vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tu(vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tu(vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tu(vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tum(vbool32_t vm,
+                                                      vfloat32m1_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tum(vbool16_t vm,
+                                                      vfloat32m2_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tum(vbool8_t vm,
+                                                      vfloat32m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tum(vbool4_t vm,
+                                                      vfloat32m8_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      vbfloat16m1_t vs1,
+                                                      size_t vl) {
+  return __riscv_vfwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_tumu(vbool32_t vm,
+                                                       vfloat32m1_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_tumu(vbool16_t vm,
+                                                       vfloat32m2_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_tumu(vbool8_t vm,
+                                                       vfloat32m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_tumu(vbool4_t vm,
+                                                       vfloat32m8_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       vbfloat16m1_t vs1,
+                                                       size_t vl) {
+  return __riscv_vfwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m1_t test_vfwbdota_vv_bf16m8_bf16m1_f32m1_mu(vbool32_t vm,
+                                                     vfloat32m1_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m2_t test_vfwbdota_vv_bf16m8_bf16m1_f32m2_mu(vbool16_t vm,
+                                                     vfloat32m2_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m4_t test_vfwbdota_vv_bf16m8_bf16m1_f32m4_mu(vbool8_t vm,
+                                                     vfloat32m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vfloat32m8_t test_vfwbdota_vv_bf16m8_bf16m1_f32m8_mu(vbool4_t vm,
+                                                     vfloat32m8_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     vbfloat16m1_t vs1,
+                                                     size_t vl) {
+  return __riscv_vfwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/overloaded-api-testing/vqwbdota.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vqwbdota.c
@@ -1,0 +1,740 @@
+#include <riscv_vector.h>
+#include <stdint.h>
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tu(vint32m1_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tu(vint32m2_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tu(vint32m4_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
+                                               vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tu(vint32m1_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tu(vint32m2_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tu(vint32m4_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2,
+                                               vint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tu(vuint32m1_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tu(vuint32m2_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tu(vuint32m4_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2,
+                                                vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tum(vbool32_t vm, vint32m1_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tum(vbool16_t vm, vint32m2_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tum(vbool8_t vm, vint32m4_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tum(vbool4_t vm, vint32m8_t vd,
+                                                vuint8m8_t vs2, vint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
+                                                 vuint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vint8m8_t vs2, vuint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
+                                                 vuint8m8_t vs2, vint8m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
+                                                  vuint8m8_t vs2,
+                                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_i8m8_u8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_i8m8_u8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_i8m8_u8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_i8m8_u8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vint8m8_t vs2, vuint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m1_t test_vqwbdota_vv_u8m8_i8m1_i32m1_mu(vbool32_t vm, vint32m1_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m2_t test_vqwbdota_vv_u8m8_i8m1_i32m2_mu(vbool16_t vm, vint32m2_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m4_t test_vqwbdota_vv_u8m8_i8m1_i32m4_mu(vbool8_t vm, vint32m4_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint32m8_t test_vqwbdota_vv_u8m8_i8m1_i32m8_mu(vbool4_t vm, vint32m8_t vd,
+                                               vuint8m8_t vs2, vint8m1_t vs1,
+                                               size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m1_t test_vqwbdota_vv_u8m8_u8m1_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m2_t test_vqwbdota_vv_u8m8_u8m1_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m4_t test_vqwbdota_vv_u8m8_u8m1_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint32m8_t test_vqwbdota_vv_u8m8_u8m1_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
+                                                vuint8m8_t vs2, vuint8m1_t vs1,
+                                                size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tu(vint64m1_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tu(vint64m2_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tu(vint64m4_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tu(vint64m8_t vd, vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tu(vint64m1_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tu(vint64m2_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tu(vint64m4_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tu(vint64m8_t vd, vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tu(vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tu(vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tu(vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tu(vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tu(vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tum(vbool64_t vm, vint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tum(vbool32_t vm, vint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tum(vbool16_t vm, vint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tum(vbool8_t vm, vint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tum(vbool64_t vm, vuint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tum(vbool32_t vm, vuint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tum(vbool16_t vm, vuint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tum(vbool8_t vm, vuint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tum(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vint16m8_t vs2,
+                                                   vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_tumu(vbool64_t vm, vint64m1_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_tumu(vbool32_t vm, vint64m2_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_tumu(vbool16_t vm, vint64m4_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_tumu(vbool8_t vm, vint64m8_t vd,
+                                                   vuint16m8_t vs2,
+                                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_tumu(
+    vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_tumu(
+    vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_tumu(
+    vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_tumu(vbool8_t vm, vuint64m8_t vd,
+                                                    vuint16m8_t vs2,
+                                                    vuint16m1_t vs1,
+                                                    size_t vl) {
+  return __riscv_vqwbdota_tumu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vint16m8_t vs2, vint16m1_t vs1,
+                                                 size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_i16m8_u16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_i16m8_u16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_i16m8_u16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_i16m8_u16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vint16m8_t vs2,
+                                                 vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m1_t test_vqwbdota_vv_u16m8_i16m1_i64m1_mu(vbool64_t vm, vint64m1_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m2_t test_vqwbdota_vv_u16m8_i16m1_i64m2_mu(vbool32_t vm, vint64m2_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m4_t test_vqwbdota_vv_u16m8_i16m1_i64m4_mu(vbool16_t vm, vint64m4_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vint64m8_t test_vqwbdota_vv_u16m8_i16m1_i64m8_mu(vbool8_t vm, vint64m8_t vd,
+                                                 vuint16m8_t vs2,
+                                                 vint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m1_t test_vqwbdota_vv_u16m8_u16m1_u64m1_mu(vbool64_t vm, vuint64m1_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m2_t test_vqwbdota_vv_u16m8_u16m1_u64m2_mu(vbool32_t vm, vuint64m2_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m4_t test_vqwbdota_vv_u16m8_u16m1_u64m4_mu(vbool16_t vm, vuint64m4_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}
+
+vuint64m8_t test_vqwbdota_vv_u16m8_u16m1_u64m8_mu(vbool8_t vm, vuint64m8_t vd,
+                                                  vuint16m8_t vs2,
+                                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vqwbdota_mu(vm, vd, vs2, vs1, 0, vl);
+}

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs.adoc
@@ -80297,3 +80297,628 @@ vfloat32m1_t __riscv_vfqwdota_tum(vbool1_t vm, vfloat32m1_t vd,
                                   vfloat8e5m2m8_t vs2, vfloat8e5m2m8_t vs1,
                                   size_t vl);
 ----
+
+=== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[[policy-variant-overloadedzvqwbdota8i-8-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint32m1_t __riscv_vqwbdota_tu(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tu(vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tu(vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tu(vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tu(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tu(vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tu(vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tu(vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tu(vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tu(vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tu(vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tu(vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_tu(vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                                size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota_tu(vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                                size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota_tu(vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                                size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota_tu(vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                                size_t ci, size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_tum(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tum(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tum(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tum(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tum(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tum(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tum(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tum(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tum(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tum(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_tum(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota_tum(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota_tum(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota_tum(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_tumu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tumu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tumu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tumu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tumu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tumu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tumu(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tumu(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tumu(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tumu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_tumu(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2,
+                                  vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota_tumu(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2,
+                                  vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota_tumu(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2,
+                                  vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota_tumu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+                                  vuint8m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_mu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_mu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_mu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_mu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                               vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_mu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                               vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_mu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                               vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                               vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_mu(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_mu(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_mu(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_mu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_mu(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota_mu(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota_mu(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota_mu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+----
+
+=== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[[policy-variant-overloadedzvqwbdota16i-16-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint64m1_t __riscv_vqwbdota_tu(vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tu(vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tu(vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tu(vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tu(vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tu(vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tu(vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tu(vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tu(vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tu(vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tu(vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tu(vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota_tu(vuint64m1_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_tu(vuint64m2_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_tu(vuint64m4_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_tu(vuint64m8_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_tum(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tum(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tum(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tum(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tum(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tum(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tum(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tum(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tum(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tum(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tum(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tum(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota_tum(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_tum(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_tum(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_tum(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_tumu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tumu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tumu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tumu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tumu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tumu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tumu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tumu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tumu(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tumu(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tumu(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tumu(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota_tumu(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2,
+                                  vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_tumu(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2,
+                                  vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_tumu(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2,
+                                  vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_tumu(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2,
+                                  vuint16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_mu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_mu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_mu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_mu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_mu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                               vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_mu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                               vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_mu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                               vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_mu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                               vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_mu(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_mu(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_mu(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_mu(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota_mu(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_mu(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_mu(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_mu(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+----
+
+=== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[[policy-variant-overloadedzvfwbdota16bf-bf16-batched-widening-dot-product]]
+==== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfwbdota_tu(vfloat32m1_t vd, vbfloat16m8_t vs2,
+                                 vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_tu(vfloat32m2_t vd, vbfloat16m8_t vs2,
+                                 vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_tu(vfloat32m4_t vd, vbfloat16m8_t vs2,
+                                 vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_tu(vfloat32m8_t vd, vbfloat16m8_t vs2,
+                                 vbfloat16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                  vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                  vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                  vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                  vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                  size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                   vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                   vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                   vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                   vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                   size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                 vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                 size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                 vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                 size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                 vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                 size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                 vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                 size_t ci, size_t vl);
+----
+
+=== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[[policy-variant-overloadedzvfqwbdota8f-fp8-batched-quad-widening-dot-product]]
+==== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfqwbdota_tu(vfloat32m1_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tu(vfloat32m2_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tu(vfloat32m4_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tu(vfloat32m8_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tu(vfloat32m1_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tu(vfloat32m2_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tu(vfloat32m4_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tu(vfloat32m8_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tu(vfloat32m1_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tu(vfloat32m2_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tu(vfloat32m4_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tu(vfloat32m8_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tu(vfloat32m1_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tu(vfloat32m2_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tu(vfloat32m4_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tu(vfloat32m8_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+----
+
+=== Zvfbdota32f - FP32 Batched Dot Product
+
+[[policy-variant-overloadedzvfbdota32f-fp32-batched-dot-product]]
+==== Zvfbdota32f - FP32 Batched Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfbdota_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                 vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                 size_t vl);
+vfloat32m2_t __riscv_vfbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                 vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                 size_t vl);
+vfloat32m4_t __riscv_vfbdota_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                                 vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                                 vfloat32m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  size_t vl);
+vfloat32m2_t __riscv_vfbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  size_t vl);
+vfloat32m4_t __riscv_vfbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  size_t vl);
+vfloat32m8_t __riscv_vfbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfbdota_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m2_t __riscv_vfbdota_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m4_t __riscv_vfbdota_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m8_t __riscv_vfbdota_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                 vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                 unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                 vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                 unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                                 vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                 size_t vl);
+vfloat32m8_t __riscv_vfbdota_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                                 vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                 size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  unsigned int frm, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m2_t __riscv_vfbdota_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m4_t __riscv_vfbdota_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m8_t __riscv_vfbdota_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+----

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/19_zvqwbdota8i_-_8-bit_integer_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/19_zvqwbdota8i_-_8-bit_integer_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,140 @@
+
+=== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[[policy-variant-overloadedzvqwbdota8i-8-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint32m1_t __riscv_vqwbdota_tu(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tu(vint32m2_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tu(vint32m4_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tu(vint32m8_t vd, vint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tu(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tu(vint32m2_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tu(vint32m4_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tu(vint32m8_t vd, vint8m8_t vs2, vuint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tu(vint32m1_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tu(vint32m2_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tu(vint32m4_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tu(vint32m8_t vd, vuint8m8_t vs2, vint8m1_t vs1,
+                               size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_tu(vuint32m1_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                                size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota_tu(vuint32m2_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                                size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota_tu(vuint32m4_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                                size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota_tu(vuint32m8_t vd, vuint8m8_t vs2, vuint8m1_t vs1,
+                                size_t ci, size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_tum(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tum(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tum(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tum(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tum(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tum(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tum(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tum(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tum(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tum(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+                                vint8m1_t vs1, size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_tum(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota_tum(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota_tum(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota_tum(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_tumu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tumu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tumu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tumu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tumu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tumu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                                 vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_tumu(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_tumu(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_tumu(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_tumu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+                                 vint8m1_t vs1, size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_tumu(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2,
+                                  vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota_tumu(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2,
+                                  vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota_tumu(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2,
+                                  vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota_tumu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+                                  vuint8m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint32m1_t __riscv_vqwbdota_mu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_mu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_mu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_mu(vbool32_t vm, vint32m1_t vd, vint8m8_t vs2,
+                               vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_mu(vbool16_t vm, vint32m2_t vd, vint8m8_t vs2,
+                               vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_mu(vbool8_t vm, vint32m4_t vd, vint8m8_t vs2,
+                               vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+                               vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_mu(vbool32_t vm, vint32m1_t vd, vuint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m2_t __riscv_vqwbdota_mu(vbool16_t vm, vint32m2_t vd, vuint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m4_t __riscv_vqwbdota_mu(vbool8_t vm, vint32m4_t vd, vuint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vint32m8_t __riscv_vqwbdota_mu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+                               vint8m1_t vs1, size_t ci, size_t vl);
+vuint32m1_t __riscv_vqwbdota_mu(vbool32_t vm, vuint32m1_t vd, vuint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m2_t __riscv_vqwbdota_mu(vbool16_t vm, vuint32m2_t vd, vuint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m4_t __riscv_vqwbdota_mu(vbool8_t vm, vuint32m4_t vd, vuint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+vuint32m8_t __riscv_vqwbdota_mu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+                                vuint8m1_t vs1, size_t ci, size_t vl);
+----

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/20_zvqwbdota16i_-_16-bit_integer_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/20_zvqwbdota16i_-_16-bit_integer_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,140 @@
+
+=== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[[policy-variant-overloadedzvqwbdota16i-16-bit-integer-batched-quad-widening-dot-product]]
+==== Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product
+
+[,c]
+----
+vint64m1_t __riscv_vqwbdota_tu(vint64m1_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tu(vint64m2_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tu(vint64m4_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tu(vint64m8_t vd, vint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tu(vint64m1_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tu(vint64m2_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tu(vint64m4_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tu(vint64m8_t vd, vint16m8_t vs2, vuint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tu(vint64m1_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tu(vint64m2_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tu(vint64m4_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tu(vint64m8_t vd, vuint16m8_t vs2, vint16m1_t vs1,
+                               size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota_tu(vuint64m1_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_tu(vuint64m2_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_tu(vuint64m4_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_tu(vuint64m8_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_tum(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tum(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tum(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tum(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tum(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tum(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tum(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tum(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tum(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tum(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tum(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tum(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2,
+                                vint16m1_t vs1, size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota_tum(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_tum(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_tum(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_tum(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_tumu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tumu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tumu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tumu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tumu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tumu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tumu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tumu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                                 vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_tumu(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_tumu(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_tumu(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_tumu(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2,
+                                 vint16m1_t vs1, size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota_tumu(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2,
+                                  vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_tumu(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2,
+                                  vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_tumu(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2,
+                                  vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_tumu(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2,
+                                  vuint16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vint64m1_t __riscv_vqwbdota_mu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_mu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_mu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_mu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_mu(vbool64_t vm, vint64m1_t vd, vint16m8_t vs2,
+                               vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_mu(vbool32_t vm, vint64m2_t vd, vint16m8_t vs2,
+                               vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_mu(vbool16_t vm, vint64m4_t vd, vint16m8_t vs2,
+                               vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_mu(vbool8_t vm, vint64m8_t vd, vint16m8_t vs2,
+                               vuint16m1_t vs1, size_t ci, size_t vl);
+vint64m1_t __riscv_vqwbdota_mu(vbool64_t vm, vint64m1_t vd, vuint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m2_t __riscv_vqwbdota_mu(vbool32_t vm, vint64m2_t vd, vuint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m4_t __riscv_vqwbdota_mu(vbool16_t vm, vint64m4_t vd, vuint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vint64m8_t __riscv_vqwbdota_mu(vbool8_t vm, vint64m8_t vd, vuint16m8_t vs2,
+                               vint16m1_t vs1, size_t ci, size_t vl);
+vuint64m1_t __riscv_vqwbdota_mu(vbool64_t vm, vuint64m1_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m2_t __riscv_vqwbdota_mu(vbool32_t vm, vuint64m2_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m4_t __riscv_vqwbdota_mu(vbool16_t vm, vuint64m4_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+vuint64m8_t __riscv_vqwbdota_mu(vbool8_t vm, vuint64m8_t vd, vuint16m8_t vs2,
+                                vuint16m1_t vs1, size_t ci, size_t vl);
+----

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/21_zvfwbdota16bf_-_bf16_batched_widening_dot_product.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/21_zvfwbdota16bf_-_bf16_batched_widening_dot_product.adoc
@@ -1,0 +1,56 @@
+
+=== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[[policy-variant-overloadedzvfwbdota16bf-bf16-batched-widening-dot-product]]
+==== Zvfwbdota16bf - BF16 Batched Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfwbdota_tu(vfloat32m1_t vd, vbfloat16m8_t vs2,
+                                 vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_tu(vfloat32m2_t vd, vbfloat16m8_t vs2,
+                                 vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_tu(vfloat32m4_t vd, vbfloat16m8_t vs2,
+                                 vbfloat16m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_tu(vfloat32m8_t vd, vbfloat16m8_t vs2,
+                                 vbfloat16m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                  vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                  vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                  vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                  vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                  size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                   vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                   vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                   vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                   vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                   size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                 vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                 size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                 vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                 size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                 vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                 size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                 vbfloat16m8_t vs2, vbfloat16m1_t vs1,
+                                 size_t ci, size_t vl);
+----

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/22_zvfqwbdota8f_-_fp8_batched_quad-widening_dot_product.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/22_zvfqwbdota8f_-_fp8_batched_quad-widening_dot_product.adoc
@@ -1,0 +1,188 @@
+
+=== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[[policy-variant-overloadedzvfqwbdota8f-fp8-batched-quad-widening-dot-product]]
+==== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfqwbdota_tu(vfloat32m1_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tu(vfloat32m2_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tu(vfloat32m4_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tu(vfloat32m8_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tu(vfloat32m1_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tu(vfloat32m2_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tu(vfloat32m4_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tu(vfloat32m8_t vd, vfloat8e4m3m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tu(vfloat32m1_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tu(vfloat32m2_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tu(vfloat32m4_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tu(vfloat32m8_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tu(vfloat32m1_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tu(vfloat32m2_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tu(vfloat32m4_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tu(vfloat32m8_t vd, vfloat8e5m2m8_t vs2,
+                                  vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                   vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tum(vbool8_t vm, vfloat32m4_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tum(vbool4_t vm, vfloat32m8_t vd,
+                                   vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                   size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                    vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                    vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                    size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfqwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_mu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfqwbdota_mu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfqwbdota_mu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfqwbdota_mu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1,
+                                  size_t ci, size_t vl);
+----

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/23_zvfbdota32f_-_fp32_batched_dot_product.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/23_zvfbdota32f_-_fp32_batched_dot_product.adoc
@@ -1,0 +1,101 @@
+
+=== Zvfbdota32f - FP32 Batched Dot Product
+
+[[policy-variant-overloadedzvfbdota32f-fp32-batched-dot-product]]
+==== Zvfbdota32f - FP32 Batched Dot Product
+
+[,c]
+----
+vfloat32m1_t __riscv_vfbdota_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                 vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                 size_t vl);
+vfloat32m2_t __riscv_vfbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                 vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                 size_t vl);
+vfloat32m4_t __riscv_vfbdota_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                                 vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                                 vfloat32m1_t vs1, size_t ci, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  size_t vl);
+vfloat32m2_t __riscv_vfbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  size_t vl);
+vfloat32m4_t __riscv_vfbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  size_t vl);
+vfloat32m8_t __riscv_vfbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m2_t __riscv_vfbdota_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m4_t __riscv_vfbdota_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m8_t __riscv_vfbdota_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfbdota_tu(vfloat32m1_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m2_t __riscv_vfbdota_tu(vfloat32m2_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m4_t __riscv_vfbdota_tu(vfloat32m4_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m8_t __riscv_vfbdota_tu(vfloat32m8_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_tum(vbool32_t vm, vfloat32m1_t vd,
+                                 vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                 unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_tum(vbool16_t vm, vfloat32m2_t vd,
+                                 vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                 unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_tum(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                                 vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                 size_t vl);
+vfloat32m8_t __riscv_vfbdota_tum(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                                 vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                 size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_tumu(vbool32_t vm, vfloat32m1_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  unsigned int frm, size_t vl);
+vfloat32m2_t __riscv_vfbdota_tumu(vbool16_t vm, vfloat32m2_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  unsigned int frm, size_t vl);
+vfloat32m4_t __riscv_vfbdota_tumu(vbool8_t vm, vfloat32m4_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  unsigned int frm, size_t vl);
+vfloat32m8_t __riscv_vfbdota_tumu(vbool4_t vm, vfloat32m8_t vd,
+                                  vfloat32m8_t vs2, vfloat32m1_t vs1, size_t ci,
+                                  unsigned int frm, size_t vl);
+// masked functions
+vfloat32m1_t __riscv_vfbdota_mu(vbool32_t vm, vfloat32m1_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m2_t __riscv_vfbdota_mu(vbool16_t vm, vfloat32m2_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m4_t __riscv_vfbdota_mu(vbool8_t vm, vfloat32m4_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+vfloat32m8_t __riscv_vfbdota_mu(vbool4_t vm, vfloat32m8_t vd, vfloat32m8_t vs2,
+                                vfloat32m1_t vs1, size_t ci, unsigned int frm,
+                                size_t vl);
+----

--- a/doc/rvv-intrinsic-spec.adoc
+++ b/doc/rvv-intrinsic-spec.adoc
@@ -391,6 +391,34 @@ vfloat32m1_t __riscv_vfqwdota_vv_f8e5m2m1_f8e4m3m1_f32m1(vfloat32m1_t vd, vfloat
 vfloat32m1_t __riscv_vfqwdota_vv_f8e5m2m1_f8e5m2m1_f32m1(vfloat32m1_t vd, vfloat8e5m2m1_t vs2, vfloat8e5m2m1_t vs1, size_t vl);
 ----
 
+==== Zvbdota Batched Dot Product instructions
+
+For Zvbdota family batched dot product instructions, the intrinsics follow a similar naming pattern to Zvdota, encoding the input and output vector types in the suffix. The naming pattern is `{OP}_vv_{VS2_TYPE}{VS2_SEW}m{VS2_LMUL}_{VS1_TYPE}{VS1_SEW}m{VS1_LMUL}_{VD_TYPE}{VD_SEW}m{VD_LMUL}`.
+
+===== Zvqwbdota8i/Zvqwbdota16i - Integer Batched Quad-Widening Dot Product instructions
+[,c]
+----
+vint32m1_t __riscv_vqwbdota_vv_i8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_i8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_i8m1_i32m1(vint32m1_t vd, vint8m8_t vs2, vint8m1_t vs1, size_t ci, size_t vl);
+vint32m1_t __riscv_vqwbdota_vv_u8m8_u8m1_i32m1(vint32m1_t vd, vint8m8_t vs2, vuint8m1_t vs1, size_t ci, size_t vl);
+----
+
+===== Zvfwbdota16bf - BF16 Batched Dot-Product instruction
+[,c]
+----
+vfloat32m1_t __riscv_vfwbdota_vv_bf16m8_bf16m1_f32m1(vfloat32m1_t vd, vbfloat16m8_t vs2, vbfloat16m1_t vs1, size_t ci, size_t vl);
+----
+
+===== Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product instructions
+[,c]
+----
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e4m3m1_f32m1(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e4m3m8_f8e5m2m1_f32m1(vfloat32m1_t vd, vfloat8e4m3m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e4m3m1_f32m1(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e4m3m1_t vs1, size_t ci, size_t vl);
+vfloat32m1_t __riscv_vfqwbdota_vv_f8e5m2m8_f8e5m2m1_f32m1(vfloat32m1_t vd, vfloat8e5m2m8_t vs2, vfloat8e5m2m1_t vs1, size_t ci, size_t vl);
+----
+
 [[implicit-naming-scheme]]
 === Implicit (Overloaded) naming scheme
 

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/constants.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/constants.py
@@ -21,6 +21,7 @@ This file collects constant values.
 LMULS = ["f8", "f4", "f2", 1, 2, 4, 8]
 WLMULS = ["f8", "f4", "f2", 1, 2, 4]
 NCVTLMULS = ["f4", "f2", 1, 2, 4, 8]
+NONFRACLMULS = [1, 2, 4, 8]
 SEWS = [8, 16, 32, 64]
 WSEWS = [8, 16, 32]
 FSEWS = [16, 32, 64]

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -639,6 +639,7 @@ class APITestGenerator(Generator):
     # an immediate.
     func_decl = func_decl.replace(", unsigned int vxrm", "")
     func_decl = func_decl.replace(", size_t uimm", "")
+    func_decl = func_decl.replace(", size_t ci", "")
 
     # For "frm" parameter of the floating-point intrinsics, value for it must
     # be an immediate.
@@ -679,6 +680,9 @@ class APITestGenerator(Generator):
         return "__RISCV_FRM_RNE"
 
       if arg_name == "uimm":
+        return "0"
+
+      if arg_name == "ci":
         return "0"
 
       return arg_name

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/inst.py
@@ -44,8 +44,9 @@ from templates import mask_load_store_template
 from templates import permute_template
 from templates import zvfofp8min_template
 from templates import zvdota_template
-from constants import LMULS,WLMULS,NCVTLMULS,SEWS,WSEWS,FSEWS,WFSEWS,NSEWS,\
-  TYPES,ITYPES,FTYPES,BFTYPES,F8TYPES,MTYPES,MLENS
+from templates import zvbdota_template
+from constants import NONFRACLMULS,LMULS,WLMULS,NCVTLMULS,SEWS,WSEWS,FSEWS,\
+  WFSEWS,NSEWS,TYPES,ITYPES,FTYPES,BFTYPES,F8TYPES,MTYPES,MLENS
 from generator import CompatibleHeaderGenerator
 
 
@@ -659,6 +660,63 @@ def gen(g):
       LMULS,
       decorators.has_masking_no_maskedoff_reduction_policy,
       required_ext_list=["zvfqwdota8f"])
+
+  ####################################################################
+  # Zvbdota Family of Batched Dot-Product Extensions
+  ####################################################################
+
+  g.start_group("Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product")
+  g.function_group(
+      zvbdota_template,
+      "Zvqwbdota8i - 8-bit Integer Batched Quad-Widening Dot Product",
+      "zvqwbdota8i-8-bit-integer-batched-quad-widening-dot-product",
+      ["vqwbdota"],
+      ITYPES, [8],
+      NONFRACLMULS,
+      decorators.has_masking_no_maskedoff_policy,
+      required_ext_list=["zvqwbdota8i"])
+
+  g.start_group(
+      "Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product")
+  g.function_group(
+      zvbdota_template,
+      "Zvqwbdota16i - 16-bit Integer Batched Quad-Widening Dot Product",
+      "zvqwbdota16i-16-bit-integer-batched-quad-widening-dot-product",
+      ["vqwbdota"],
+      ITYPES, [16],
+      NONFRACLMULS,
+      decorators.has_masking_no_maskedoff_policy,
+      required_ext_list=["zvqwbdota16i"])
+
+  g.start_group("Zvfwbdota16bf - BF16 Batched Widening Dot Product")
+  g.function_group(
+      zvbdota_template,
+      "Zvfwbdota16bf - BF16 Batched Widening Dot Product",
+      "zvfwbdota16bf-bf16-batched-widening-dot-product", ["vfwbdota"],
+      BFTYPES, [16],
+      NONFRACLMULS,
+      decorators.has_masking_no_maskedoff_policy,
+      required_ext_list=["zvfwbdota16bf"])
+
+  g.start_group("Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product")
+  g.function_group(
+      zvbdota_template,
+      "Zvfqwbdota8f - FP8 Batched Quad-Widening Dot Product",
+      "zvfqwbdota8f-fp8-batched-quad-widening-dot-product", ["vfqwbdota"],
+      F8TYPES, [8],
+      NONFRACLMULS,
+      decorators.has_masking_no_maskedoff_policy,
+      required_ext_list=["zvfqwbdota8f"])
+
+  g.start_group("Zvfbdota32f - FP32 Batched Dot Product")
+  g.function_group(
+      zvbdota_template,
+      "Zvfbdota32f - FP32 Batched Dot Product",
+      "zvfbdota32f-fp32-batched-dot-product", ["vfbdota"],
+      FTYPES, [32],
+      NONFRACLMULS,
+      decorators.has_masking_no_maskedoff_policy_frm,
+      required_ext_list=["zvfbdota32f"])
   ####################################################################
 
   g.gen_prologue()

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/zvbdota_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/zvbdota_template.py
@@ -1,0 +1,101 @@
+"""
+--------------------------------------------------------------------------------
+Copyright 2026 SiFive Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--------------------------------------------------------------------------------
+
+Template for rendering Zvbdota family of batched dot-product extensions
+"""
+
+from utils import prod
+from utils import TypeHelper
+from enums import InstInfo
+from enums import InstType
+from enums import ExtraAttr
+
+
+def render(G,
+           op_list,
+           type_list,
+           sew_list,
+           lmul_list,
+           decorator_list,
+           description,
+           required_ext_list=None):
+  #pylint: disable=invalid-name, unused-argument
+  G.emit_function_group_description(description)
+  G.inst_group_prologue()
+  for decorator in decorator_list:
+    decorator.write_text_header(G)
+    for args in prod(
+        OP=op_list,
+        TYPE=type_list,
+        VS1_TYPE=type_list,
+        SEW=sew_list,
+        LMUL=lmul_list):
+      op = args["OP"]
+      vs2_type = args["TYPE"]
+      vs1_type = args["VS1_TYPE"]
+
+      if "int" in vs2_type and decorator.flags & ExtraAttr.HAS_FRM:
+        continue
+
+      args["OUT_SEW"] = args["SEW"] * (4 if "qwbdota" in op else
+                                       (2 if "wbdota" in op else 1))
+      is_float = "float" in vs2_type
+
+      vs2_signed = (vs2_type == "int")
+      vs1_signed = (vs1_type == "int")
+      args["OTYPE"] = "float" if is_float else ("int" if (
+          vs2_signed or vs1_signed) else "uint")
+
+      vs1_type_helper = TypeHelper(SEW=args["SEW"], LMUL=1, TYPE=vs1_type)
+      vs2_type_helper = TypeHelper(SEW=args["SEW"], LMUL=8, TYPE=vs2_type)
+      dst_type_helper = TypeHelper(
+          SEW=args["OUT_SEW"], LMUL=args["LMUL"], TYPE=args["OTYPE"])
+
+      if not dst_type_helper.valid_vtype(dst_type_helper.v):
+        continue
+
+      vs1_type = vs1_type_helper.v
+      vs2_type = vs2_type_helper.v
+      if "float" in args["TYPE"] and args["SEW"] == 32:
+        func_name = (
+            f"{op}_vv_{args['OTYPE']}{args['OUT_SEW']}m{args['LMUL']}")
+      elif "float8" in vs2_type:
+        func_name = (f"{op}_vv_{args['TYPE']}m8_{args['VS1_TYPE']}m1_"
+                     f"{args['OTYPE']}{args['OUT_SEW']}m{args['LMUL']}")
+      else:
+        func_name = (f"{op}_vv_{args['TYPE']}{args['SEW']}m8_"
+                     f"{args['VS1_TYPE']}{args['SEW']}m1_"
+                     f"{args['OTYPE']}{args['OUT_SEW']}m{args['LMUL']}")
+
+      G.func(
+          InstInfo.get(
+              args,
+              decorator,
+              InstType.VVV,
+              extra_attr=ExtraAttr.MAC,
+              required_ext=required_ext_list),
+          name=func_name + decorator.func_suffix,
+          return_type=dst_type_helper.v,
+          **decorator.mask_args(dst_type_helper.m, dst_type_helper.v),
+          vd=dst_type_helper.v,
+          vs2=vs2_type,
+          vs1=vs1_type,
+          ci="size_t",
+          **decorator.extra_csr_args(dst_type_helper.uint),
+          vl=dst_type_helper.size_t)
+
+  G.inst_group_epilogue()


### PR DESCRIPTION
spec: https://github.com/aswaterman/riscv-misc/blob/main/isa/ldot-bdot/ldot-bdot.adoc#zvbdota-family-of-batched-dot-product-extensions-version-02

stacked on: https://github.com/riscv-non-isa/riscv-rvv-intrinsic-doc/pull/427