### PR TITLE
Fix vwabda[u] operand order

### DIFF
--- a/auto-generated/api-testing/vwabda.c
+++ b/auto-generated/api-testing/vwabda.c
@@ -1,116 +1,116 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs1,
-                                   vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs2,
+                                   vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs1,
-                                   vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs2,
+                                   vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2,
+vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u16m1(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m1(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
+vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u16m2(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m2(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2,
+vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u16m4(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m4(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2,
+vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u16m8(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m8(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs1,
-                                   vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs2,
+                                   vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs1,
-                                 vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs2,
+                                 vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2,
+vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u32m2(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m2(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2,
+vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u32m4(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m4(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2,
+vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u32m8(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m8(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                     vint8mf8_t vs1, vint8mf8_t vs2,
+                                     vint8mf8_t vs2, vint8mf8_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf4_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                     vint8mf4_t vs1, vint8mf4_t vs2,
+                                     vint8mf4_t vs2, vint8mf4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                                   vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_m(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                                   vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                   vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_m(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                   vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                   vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_m(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                   vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                   vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_m(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                   vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                     vint16mf4_t vs1, vint16mf4_t vs2,
+                                     vint16mf4_t vs2, vint16mf4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32mf2_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                   vint16mf2_t vs1, vint16mf2_t vs2,
+                                   vint16mf2_t vs2, vint16mf2_t vs1,
                                    size_t vl) {
-  return __riscv_vwabda_vv_u32m1_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                                   vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_m(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                   vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_m(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                   vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                   vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_m(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                   vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_m(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/api-testing/vwabdau.c
+++ b/auto-generated/api-testing/vwabdau.c
@@ -1,120 +1,120 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                    vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                    vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                    vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                    vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs1,
-                                  vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs2,
+                                  vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs1,
-                                  vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs2,
+                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs1,
-                                  vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs2,
+                                  vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs1,
-                                  vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs2,
+                                  vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                    vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                    vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs1,
-                                  vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs2,
+                                  vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs1,
-                                  vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs2,
+                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs1,
-                                  vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs2,
+                                  vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs1,
-                                  vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs2,
+                                  vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                      vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                      vuint8mf8_t vs2, vuint8mf8_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf4_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                      vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                      vuint8mf4_t vs2, vuint8mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf2_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd,
-                                    vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                    vuint8mf2_t vs2, vuint8mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                                    vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_m(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                                    vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                                    vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_m(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                                    vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                                    vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_m(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                                    vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                      vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                      vuint16mf4_t vs2, vuint16mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32mf2_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                    vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                    vuint16mf2_t vs2, vuint16mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m1_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd,
-                                    vuint16m1_t vs1, vuint16m1_t vs2,
+                                    vuint16m1_t vs2, vuint16m1_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m2_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd,
-                                    vuint16m2_t vs1, vuint16m2_t vs2,
+                                    vuint16m2_t vs2, vuint16m2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m4_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
-                                    vuint16m4_t vs1, vuint16m4_t vs2,
+                                    vuint16m4_t vs2, vuint16m4_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m8_m(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/gnu-api-tests/vwabda.c
+++ b/auto-generated/gnu-api-tests/vwabda.c
@@ -3,91 +3,91 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8(vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_m(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_m(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_m(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_m(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_m(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_m(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_m(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1_m(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_m(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_m(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_m(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_m(vm, vd, vs2, vs1, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vwabda\.[ivxfswum.]+\s+} 22 } } */

--- a/auto-generated/gnu-api-tests/vwabdau.c
+++ b/auto-generated/gnu-api-tests/vwabdau.c
@@ -3,91 +3,91 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8(vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_m(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_m(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_m(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_m(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_m(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_m(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_m(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_m(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_m(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_m(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_m(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8_m(vm, vd, vs2, vs1, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vwabdau\.[ivxfswum.]+\s+} 22 } } */

--- a/auto-generated/gnu-overloaded-tests/vwabda.c
+++ b/auto-generated/gnu-overloaded-tests/vwabda.c
@@ -3,91 +3,91 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vwabda\.[ivxfswum.]+\s+} 22 } } */

--- a/auto-generated/gnu-overloaded-tests/vwabdau.c
+++ b/auto-generated/gnu-overloaded-tests/vwabdau.c
@@ -3,91 +3,91 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vwabdau\.[ivxfswum.]+\s+} 22 } } */

--- a/auto-generated/intrinsic_funcs.adoc
+++ b/auto-generated/intrinsic_funcs.adoc
@@ -53904,58 +53904,58 @@ vuint16m8_t __riscv_vabdu_vv_u16m8_m(vbool2_t vm, vuint16m8_t vs2,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs1,
-                                      vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs1,
-                                      vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs1,
-                                    vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs1,
-                                      vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs1,
-                                    vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs1,
-                                    vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs2,
+                                      vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs2,
+                                      vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs2,
+                                    vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs2,
+                                      vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs2,
+                                    vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs2,
+                                    vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                        vint8mf8_t vs1, vint8mf8_t vs2,
+                                        vint8mf8_t vs2, vint8mf8_t vs1,
                                         size_t vl);
 vuint16mf2_t __riscv_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                        vint8mf4_t vs1, vint8mf4_t vs2,
+                                        vint8mf4_t vs2, vint8mf4_t vs1,
                                         size_t vl);
 vuint16m1_t __riscv_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd,
-                                      vint8mf2_t vs1, vint8mf2_t vs2,
+                                      vint8mf2_t vs2, vint8mf2_t vs1,
                                       size_t vl);
 vuint16m2_t __riscv_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd,
-                                      vint8m1_t vs1, vint8m1_t vs2, size_t vl);
+                                      vint8m1_t vs2, vint8m1_t vs1, size_t vl);
 vuint16m4_t __riscv_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd,
-                                      vint8m2_t vs1, vint8m2_t vs2, size_t vl);
+                                      vint8m2_t vs2, vint8m2_t vs1, size_t vl);
 vuint16m8_t __riscv_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd,
-                                      vint8m4_t vs1, vint8m4_t vs2, size_t vl);
+                                      vint8m4_t vs2, vint8m4_t vs1, size_t vl);
 vuint32mf2_t __riscv_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                        vint16mf4_t vs1, vint16mf4_t vs2,
+                                        vint16mf4_t vs2, vint16mf4_t vs1,
                                         size_t vl);
 vuint32m1_t __riscv_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                      vint16mf2_t vs1, vint16mf2_t vs2,
+                                      vint16mf2_t vs2, vint16mf2_t vs1,
                                       size_t vl);
 vuint32m2_t __riscv_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd,
-                                      vint16m1_t vs1, vint16m1_t vs2,
+                                      vint16m1_t vs2, vint16m1_t vs1,
                                       size_t vl);
 vuint32m4_t __riscv_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd,
-                                      vint16m2_t vs1, vint16m2_t vs2,
+                                      vint16m2_t vs2, vint16m2_t vs1,
                                       size_t vl);
 vuint32m8_t __riscv_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
-                                      vint16m4_t vs1, vint16m4_t vs2,
+                                      vint16m4_t vs2, vint16m4_t vs1,
                                       size_t vl);
 ----
 
@@ -53964,61 +53964,61 @@ vuint32m8_t __riscv_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                       vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                       vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs1,
-                                     vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs1,
-                                     vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs1,
-                                     vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs1,
-                                     vuint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                       vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs1,
-                                     vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs1,
-                                     vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs1,
-                                     vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs1,
-                                     vuint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs2,
+                                     vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs2,
+                                     vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs2,
+                                     vuint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs2,
+                                     vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs2,
+                                     vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs2,
+                                     vuint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                         vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                         vuint8mf8_t vs2, vuint8mf8_t vs1,
                                          size_t vl);
 vuint16mf2_t __riscv_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                         vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                         vuint8mf4_t vs2, vuint8mf4_t vs1,
                                          size_t vl);
 vuint16m1_t __riscv_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd,
-                                       vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                       vuint8mf2_t vs2, vuint8mf2_t vs1,
                                        size_t vl);
 vuint16m2_t __riscv_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd,
-                                       vuint8m1_t vs1, vuint8m1_t vs2,
+                                       vuint8m1_t vs2, vuint8m1_t vs1,
                                        size_t vl);
 vuint16m4_t __riscv_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd,
-                                       vuint8m2_t vs1, vuint8m2_t vs2,
+                                       vuint8m2_t vs2, vuint8m2_t vs1,
                                        size_t vl);
 vuint16m8_t __riscv_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd,
-                                       vuint8m4_t vs1, vuint8m4_t vs2,
+                                       vuint8m4_t vs2, vuint8m4_t vs1,
                                        size_t vl);
 vuint32mf2_t __riscv_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                         vuint16mf4_t vs2, vuint16mf4_t vs1,
                                          size_t vl);
 vuint32m1_t __riscv_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                       vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                       vuint16mf2_t vs2, vuint16mf2_t vs1,
                                        size_t vl);
 vuint32m2_t __riscv_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd,
-                                       vuint16m1_t vs1, vuint16m1_t vs2,
+                                       vuint16m1_t vs2, vuint16m1_t vs1,
                                        size_t vl);
 vuint32m4_t __riscv_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd,
-                                       vuint16m2_t vs1, vuint16m2_t vs2,
+                                       vuint16m2_t vs2, vuint16m2_t vs1,
                                        size_t vl);
 vuint32m8_t __riscv_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
-                                       vuint16m4_t vs1, vuint16m4_t vs2,
+                                       vuint16m4_t vs2, vuint16m4_t vs1,
                                        size_t vl);
 ----
 

--- a/auto-generated/intrinsic_funcs/14_zvabd_-_vector_absolute_difference_instructions.adoc
+++ b/auto-generated/intrinsic_funcs/14_zvabd_-_vector_absolute_difference_instructions.adoc
@@ -156,58 +156,58 @@ vuint16m8_t __riscv_vabdu_vv_u16m8_m(vbool2_t vm, vuint16m8_t vs2,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs1,
-                                      vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs1,
-                                      vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs1,
-                                    vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs1,
-                                      vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs1,
-                                    vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs1,
-                                    vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs2,
+                                      vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs2,
+                                      vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs2,
+                                    vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs2,
+                                      vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs2,
+                                    vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs2,
+                                    vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                        vint8mf8_t vs1, vint8mf8_t vs2,
+                                        vint8mf8_t vs2, vint8mf8_t vs1,
                                         size_t vl);
 vuint16mf2_t __riscv_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                        vint8mf4_t vs1, vint8mf4_t vs2,
+                                        vint8mf4_t vs2, vint8mf4_t vs1,
                                         size_t vl);
 vuint16m1_t __riscv_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd,
-                                      vint8mf2_t vs1, vint8mf2_t vs2,
+                                      vint8mf2_t vs2, vint8mf2_t vs1,
                                       size_t vl);
 vuint16m2_t __riscv_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd,
-                                      vint8m1_t vs1, vint8m1_t vs2, size_t vl);
+                                      vint8m1_t vs2, vint8m1_t vs1, size_t vl);
 vuint16m4_t __riscv_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd,
-                                      vint8m2_t vs1, vint8m2_t vs2, size_t vl);
+                                      vint8m2_t vs2, vint8m2_t vs1, size_t vl);
 vuint16m8_t __riscv_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd,
-                                      vint8m4_t vs1, vint8m4_t vs2, size_t vl);
+                                      vint8m4_t vs2, vint8m4_t vs1, size_t vl);
 vuint32mf2_t __riscv_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                        vint16mf4_t vs1, vint16mf4_t vs2,
+                                        vint16mf4_t vs2, vint16mf4_t vs1,
                                         size_t vl);
 vuint32m1_t __riscv_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                      vint16mf2_t vs1, vint16mf2_t vs2,
+                                      vint16mf2_t vs2, vint16mf2_t vs1,
                                       size_t vl);
 vuint32m2_t __riscv_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd,
-                                      vint16m1_t vs1, vint16m1_t vs2,
+                                      vint16m1_t vs2, vint16m1_t vs1,
                                       size_t vl);
 vuint32m4_t __riscv_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd,
-                                      vint16m2_t vs1, vint16m2_t vs2,
+                                      vint16m2_t vs2, vint16m2_t vs1,
                                       size_t vl);
 vuint32m8_t __riscv_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
-                                      vint16m4_t vs1, vint16m4_t vs2,
+                                      vint16m4_t vs2, vint16m4_t vs1,
                                       size_t vl);
 ----
 
@@ -216,60 +216,60 @@ vuint32m8_t __riscv_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                       vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                       vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs1,
-                                     vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs1,
-                                     vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs1,
-                                     vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs1,
-                                     vuint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                       vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs1,
-                                     vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs1,
-                                     vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs1,
-                                     vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs1,
-                                     vuint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs2,
+                                     vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs2,
+                                     vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs2,
+                                     vuint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs2,
+                                     vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs2,
+                                     vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs2,
+                                     vuint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                         vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                         vuint8mf8_t vs2, vuint8mf8_t vs1,
                                          size_t vl);
 vuint16mf2_t __riscv_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                         vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                         vuint8mf4_t vs2, vuint8mf4_t vs1,
                                          size_t vl);
 vuint16m1_t __riscv_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd,
-                                       vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                       vuint8mf2_t vs2, vuint8mf2_t vs1,
                                        size_t vl);
 vuint16m2_t __riscv_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd,
-                                       vuint8m1_t vs1, vuint8m1_t vs2,
+                                       vuint8m1_t vs2, vuint8m1_t vs1,
                                        size_t vl);
 vuint16m4_t __riscv_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd,
-                                       vuint8m2_t vs1, vuint8m2_t vs2,
+                                       vuint8m2_t vs2, vuint8m2_t vs1,
                                        size_t vl);
 vuint16m8_t __riscv_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd,
-                                       vuint8m4_t vs1, vuint8m4_t vs2,
+                                       vuint8m4_t vs2, vuint8m4_t vs1,
                                        size_t vl);
 vuint32mf2_t __riscv_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                         vuint16mf4_t vs2, vuint16mf4_t vs1,
                                          size_t vl);
 vuint32m1_t __riscv_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                       vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                       vuint16mf2_t vs2, vuint16mf2_t vs1,
                                        size_t vl);
 vuint32m2_t __riscv_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd,
-                                       vuint16m1_t vs1, vuint16m1_t vs2,
+                                       vuint16m1_t vs2, vuint16m1_t vs1,
                                        size_t vl);
 vuint32m4_t __riscv_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd,
-                                       vuint16m2_t vs1, vuint16m2_t vs2,
+                                       vuint16m2_t vs2, vuint16m2_t vs1,
                                        size_t vl);
 vuint32m8_t __riscv_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
-                                       vuint16m4_t vs1, vuint16m4_t vs2,
+                                       vuint16m4_t vs2, vuint16m4_t vs1,
                                        size_t vl);
 ----

--- a/auto-generated/llvm-api-tests/vwabda.c
+++ b/auto-generated/llvm-api-tests/vwabda.c
@@ -7,116 +7,116 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs1,
-                                   vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs2,
+                                   vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs1,
-                                   vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs2,
+                                   vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2,
+vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u16m1(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m1(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
+vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u16m2(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m2(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2,
+vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u16m4(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m4(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2,
+vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u16m8(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m8(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs1,
-                                   vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs2,
+                                   vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs1,
-                                 vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs2,
+                                 vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2,
+vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u32m2(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m2(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2,
+vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u32m4(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m4(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2,
+vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda_vv_u32m8(vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m8(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                     vint8mf8_t vs1, vint8mf8_t vs2,
+                                     vint8mf8_t vs2, vint8mf8_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf4_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                     vint8mf4_t vs1, vint8mf4_t vs2,
+                                     vint8mf4_t vs2, vint8mf4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                                   vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_m(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                                   vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                   vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_m(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                   vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                   vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_m(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                   vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                   vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_m(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                   vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                     vint16mf4_t vs1, vint16mf4_t vs2,
+                                     vint16mf4_t vs2, vint16mf4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32mf2_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                   vint16mf2_t vs1, vint16mf2_t vs2,
+                                   vint16mf2_t vs2, vint16mf2_t vs1,
                                    size_t vl) {
-  return __riscv_vwabda_vv_u32m1_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                                   vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_m(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                   vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_m(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                   vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                   vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_m(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                   vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_m(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/llvm-api-tests/vwabdau.c
+++ b/auto-generated/llvm-api-tests/vwabdau.c
@@ -7,120 +7,120 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                    vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                    vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                    vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                    vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs1,
-                                  vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs2,
+                                  vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs1,
-                                  vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs2,
+                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs1,
-                                  vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs2,
+                                  vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs1,
-                                  vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs2,
+                                  vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                    vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                    vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs1,
-                                  vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs2,
+                                  vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs1,
-                                  vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs2,
+                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs1,
-                                  vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs2,
+                                  vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs1,
-                                  vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs2,
+                                  vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                      vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                      vuint8mf8_t vs2, vuint8mf8_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf4_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                      vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                      vuint8mf4_t vs2, vuint8mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf2_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd,
-                                    vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                    vuint8mf2_t vs2, vuint8mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m1_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                                    vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_m(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                                    vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                                    vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_m(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                                    vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4_m(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                                    vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_m(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                                    vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                      vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                      vuint16mf4_t vs2, vuint16mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32mf2_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                    vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                    vuint16mf2_t vs2, vuint16mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m1_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd,
-                                    vuint16m1_t vs1, vuint16m1_t vs2,
+                                    vuint16m1_t vs2, vuint16m1_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m2_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd,
-                                    vuint16m2_t vs1, vuint16m2_t vs2,
+                                    vuint16m2_t vs2, vuint16m2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m4_m(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
-                                    vuint16m4_t vs1, vuint16m4_t vs2,
+                                    vuint16m4_t vs2, vuint16m4_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_m(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m8_m(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/llvm-overloaded-tests/vwabda.c
+++ b/auto-generated/llvm-overloaded-tests/vwabda.c
@@ -7,116 +7,116 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs1,
-                                   vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs2,
+                                   vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs1,
-                                   vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs2,
+                                   vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2,
+vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
+vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2,
+vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2,
+vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs1,
-                                   vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs2,
+                                   vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs1,
-                                 vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs2,
+                                 vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2,
+vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2,
+vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2,
+vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                     vint8mf8_t vs1, vint8mf8_t vs2,
+                                     vint8mf8_t vs2, vint8mf8_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                     vint8mf4_t vs1, vint8mf4_t vs2,
+                                     vint8mf4_t vs2, vint8mf4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                                   vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                                   vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                   vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                   vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                   vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                   vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                   vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                   vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                     vint16mf4_t vs1, vint16mf4_t vs2,
+                                     vint16mf4_t vs2, vint16mf4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                   vint16mf2_t vs1, vint16mf2_t vs2,
+                                   vint16mf2_t vs2, vint16mf2_t vs1,
                                    size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                                   vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                   vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                   vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                   vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                   vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/llvm-overloaded-tests/vwabdau.c
+++ b/auto-generated/llvm-overloaded-tests/vwabdau.c
@@ -7,120 +7,120 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                    vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                    vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                    vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                    vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs1,
-                                  vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs2,
+                                  vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs1,
-                                  vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs2,
+                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs1,
-                                  vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs2,
+                                  vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs1,
-                                  vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs2,
+                                  vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                    vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                    vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs1,
-                                  vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs2,
+                                  vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs1,
-                                  vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs2,
+                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs1,
-                                  vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs2,
+                                  vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs1,
-                                  vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs2,
+                                  vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                      vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                      vuint8mf8_t vs2, vuint8mf8_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                      vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                      vuint8mf4_t vs2, vuint8mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd,
-                                    vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                    vuint8mf2_t vs2, vuint8mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                                    vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                                    vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                                    vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                                    vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                                    vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                                    vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                      vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                      vuint16mf4_t vs2, vuint16mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                    vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                    vuint16mf2_t vs2, vuint16mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd,
-                                    vuint16m1_t vs1, vuint16m1_t vs2,
+                                    vuint16m1_t vs2, vuint16m1_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd,
-                                    vuint16m2_t vs1, vuint16m2_t vs2,
+                                    vuint16m2_t vs2, vuint16m2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
-                                    vuint16m4_t vs1, vuint16m4_t vs2,
+                                    vuint16m4_t vs2, vuint16m4_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/overloaded-api-testing/vwabda.c
+++ b/auto-generated/overloaded-api-testing/vwabda.c
@@ -1,116 +1,116 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs1,
-                                   vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4(vuint16mf4_t vd, vint8mf8_t vs2,
+                                   vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs1,
-                                   vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2(vuint16mf2_t vd, vint8mf4_t vs2,
+                                   vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2,
+vuint16m1_t test_vwabda_vv_u16m1(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
+vuint16m2_t test_vwabda_vv_u16m2(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2,
+vuint16m4_t test_vwabda_vv_u16m4(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2,
+vuint16m8_t test_vwabda_vv_u16m8(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs1,
-                                   vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2(vuint32mf2_t vd, vint16mf4_t vs2,
+                                   vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs1,
-                                 vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1(vuint32m1_t vd, vint16mf2_t vs2,
+                                 vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2,
+vuint32m2_t test_vwabda_vv_u32m2(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2,
+vuint32m4_t test_vwabda_vv_u32m4(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2,
+vuint32m8_t test_vwabda_vv_u32m8(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1,
                                  size_t vl) {
-  return __riscv_vwabda(vd, vs1, vs2, vl);
+  return __riscv_vwabda(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                     vint8mf8_t vs1, vint8mf8_t vs2,
+                                     vint8mf8_t vs2, vint8mf8_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                     vint8mf4_t vs1, vint8mf4_t vs2,
+                                     vint8mf4_t vs2, vint8mf4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                                   vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                                   vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                   vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                   vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                   vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                   vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                   vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                   vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                     vint16mf4_t vs1, vint16mf4_t vs2,
+                                     vint16mf4_t vs2, vint16mf4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                   vint16mf2_t vs1, vint16mf2_t vs2,
+                                   vint16mf2_t vs2, vint16mf2_t vs1,
                                    size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                                   vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                                   vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                   vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                   vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                   vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                   vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/overloaded-api-testing/vwabdau.c
+++ b/auto-generated/overloaded-api-testing/vwabdau.c
@@ -1,120 +1,120 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                    vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                    vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                    vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                    vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs1,
-                                  vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1(vuint16m1_t vd, vuint8mf2_t vs2,
+                                  vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs1,
-                                  vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2(vuint16m2_t vd, vuint8m1_t vs2,
+                                  vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs1,
-                                  vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4(vuint16m4_t vd, vuint8m2_t vs2,
+                                  vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs1,
-                                  vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8(vuint16m8_t vd, vuint8m4_t vs2,
+                                  vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                    vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                    vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs1,
-                                  vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1(vuint32m1_t vd, vuint16mf2_t vs2,
+                                  vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs1,
-                                  vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2(vuint32m2_t vd, vuint16m1_t vs2,
+                                  vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs1,
-                                  vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4(vuint32m4_t vd, vuint16m2_t vs2,
+                                  vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs1,
-                                  vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8(vuint32m8_t vd, vuint16m4_t vs2,
+                                  vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_m(vbool64_t vm, vuint16mf4_t vd,
-                                      vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                      vuint8mf8_t vs2, vuint8mf8_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_m(vbool32_t vm, vuint16mf2_t vd,
-                                      vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                      vuint8mf4_t vs2, vuint8mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_m(vbool16_t vm, vuint16m1_t vd,
-                                    vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                    vuint8mf2_t vs2, vuint8mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                                    vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_m(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                                    vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                                    vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_m(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                                    vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                                    vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_m(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                                    vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                      vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                      vuint16mf4_t vs2, vuint16mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd,
-                                    vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                    vuint16mf2_t vs2, vuint16mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd,
-                                    vuint16m1_t vs1, vuint16m1_t vs2,
+                                    vuint16m1_t vs2, vuint16m1_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd,
-                                    vuint16m2_t vs1, vuint16m2_t vs2,
+                                    vuint16m2_t vs2, vuint16m2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd,
-                                    vuint16m4_t vs1, vuint16m4_t vs2,
+                                    vuint16m4_t vs2, vuint16m4_t vs1,
                                     size_t vl) {
-  return __riscv_vwabdau(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs.adoc
@@ -42327,51 +42327,51 @@ vuint16m8_t __riscv_vabdu(vbool2_t vm, vuint16m8_t vs2, vuint16m8_t vs1,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabda(vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2,
+vuint16mf4_t __riscv_vwabda(vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1,
                             size_t vl);
-vuint16mf2_t __riscv_vwabda(vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2,
+vuint16mf2_t __riscv_vwabda(vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1,
                             size_t vl);
-vuint16m1_t __riscv_vwabda(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2,
+vuint16m1_t __riscv_vwabda(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
                            size_t vl);
-vuint16m2_t __riscv_vwabda(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
+vuint16m2_t __riscv_vwabda(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1,
                            size_t vl);
-vuint16m4_t __riscv_vwabda(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2,
+vuint16m4_t __riscv_vwabda(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1,
                            size_t vl);
-vuint16m8_t __riscv_vwabda(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2,
+vuint16m8_t __riscv_vwabda(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1,
                            size_t vl);
-vuint32mf2_t __riscv_vwabda(vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2,
+vuint32mf2_t __riscv_vwabda(vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1,
                             size_t vl);
-vuint32m1_t __riscv_vwabda(vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2,
+vuint32m1_t __riscv_vwabda(vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1,
                            size_t vl);
-vuint32m2_t __riscv_vwabda(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2,
+vuint32m2_t __riscv_vwabda(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1,
                            size_t vl);
-vuint32m4_t __riscv_vwabda(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2,
+vuint32m4_t __riscv_vwabda(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1,
                            size_t vl);
-vuint32m8_t __riscv_vwabda(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2,
+vuint32m8_t __riscv_vwabda(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1,
                            size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabda(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1,
-                            vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1,
-                            vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                           vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                           vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                           vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                           vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1,
-                            vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1,
-                           vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                           vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                           vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                           vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2,
+                            vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2,
+                            vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                           vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                           vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                           vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                           vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2,
+                            vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2,
+                           vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                           vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                           vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                           vint16m4_t vs1, size_t vl);
 ----
 
 [[overloaded-vector-integer-wabdau-instructions]]
@@ -42379,51 +42379,51 @@ vuint32m8_t __riscv_vwabda(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabdau(vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2,
+vuint16mf4_t __riscv_vwabdau(vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1,
                              size_t vl);
-vuint16mf2_t __riscv_vwabdau(vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2,
+vuint16mf2_t __riscv_vwabdau(vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1,
                              size_t vl);
-vuint16m1_t __riscv_vwabdau(vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2,
+vuint16m1_t __riscv_vwabdau(vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1,
                             size_t vl);
-vuint16m2_t __riscv_vwabdau(vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2,
+vuint16m2_t __riscv_vwabdau(vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1,
                             size_t vl);
-vuint16m4_t __riscv_vwabdau(vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2,
+vuint16m4_t __riscv_vwabdau(vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1,
                             size_t vl);
-vuint16m8_t __riscv_vwabdau(vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2,
+vuint16m8_t __riscv_vwabdau(vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1,
                             size_t vl);
-vuint32mf2_t __riscv_vwabdau(vuint32mf2_t vd, vuint16mf4_t vs1,
-                             vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau(vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2,
+vuint32mf2_t __riscv_vwabdau(vuint32mf2_t vd, vuint16mf4_t vs2,
+                             vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau(vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1,
                             size_t vl);
-vuint32m2_t __riscv_vwabdau(vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2,
+vuint32m2_t __riscv_vwabdau(vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1,
                             size_t vl);
-vuint32m4_t __riscv_vwabdau(vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2,
+vuint32m4_t __riscv_vwabdau(vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1,
                             size_t vl);
-vuint32m8_t __riscv_vwabdau(vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2,
+vuint32m8_t __riscv_vwabdau(vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1,
                             size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabdau(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1,
-                             vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1,
-                             vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1,
-                            vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                            vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                            vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                            vuint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabdau(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1,
-                             vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1,
-                            vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1,
-                            vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1,
-                            vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1,
-                            vuint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2,
+                             vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2,
+                             vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2,
+                            vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                            vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                            vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                            vuint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabdau(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2,
+                             vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2,
+                            vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2,
+                            vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2,
+                            vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2,
+                            vuint16m4_t vs1, size_t vl);
 ----
 
 === Zvqwdota8i - 8-bit Integer Quad-Widening Dot Product

--- a/auto-generated/overloaded_intrinsic_funcs/14_zvabd_-_vector_absolute_difference_instructions.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/14_zvabd_-_vector_absolute_difference_instructions.adoc
@@ -148,51 +148,51 @@ vuint16m8_t __riscv_vabdu(vbool2_t vm, vuint16m8_t vs2, vuint16m8_t vs1,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabda(vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2,
+vuint16mf4_t __riscv_vwabda(vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1,
                             size_t vl);
-vuint16mf2_t __riscv_vwabda(vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2,
+vuint16mf2_t __riscv_vwabda(vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1,
                             size_t vl);
-vuint16m1_t __riscv_vwabda(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2,
+vuint16m1_t __riscv_vwabda(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
                            size_t vl);
-vuint16m2_t __riscv_vwabda(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
+vuint16m2_t __riscv_vwabda(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1,
                            size_t vl);
-vuint16m4_t __riscv_vwabda(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2,
+vuint16m4_t __riscv_vwabda(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1,
                            size_t vl);
-vuint16m8_t __riscv_vwabda(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2,
+vuint16m8_t __riscv_vwabda(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1,
                            size_t vl);
-vuint32mf2_t __riscv_vwabda(vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2,
+vuint32mf2_t __riscv_vwabda(vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1,
                             size_t vl);
-vuint32m1_t __riscv_vwabda(vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2,
+vuint32m1_t __riscv_vwabda(vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1,
                            size_t vl);
-vuint32m2_t __riscv_vwabda(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2,
+vuint32m2_t __riscv_vwabda(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1,
                            size_t vl);
-vuint32m4_t __riscv_vwabda(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2,
+vuint32m4_t __riscv_vwabda(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1,
                            size_t vl);
-vuint32m8_t __riscv_vwabda(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2,
+vuint32m8_t __riscv_vwabda(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1,
                            size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabda(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1,
-                            vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1,
-                            vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                           vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                           vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                           vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                           vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1,
-                            vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1,
-                           vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                           vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                           vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                           vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2,
+                            vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2,
+                            vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                           vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                           vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                           vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                           vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2,
+                            vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2,
+                           vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                           vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                           vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                           vint16m4_t vs1, size_t vl);
 ----
 
 [[overloaded-vector-integer-wabdau-instructions]]
@@ -200,49 +200,49 @@ vuint32m8_t __riscv_vwabda(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabdau(vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2,
+vuint16mf4_t __riscv_vwabdau(vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1,
                              size_t vl);
-vuint16mf2_t __riscv_vwabdau(vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2,
+vuint16mf2_t __riscv_vwabdau(vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1,
                              size_t vl);
-vuint16m1_t __riscv_vwabdau(vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2,
+vuint16m1_t __riscv_vwabdau(vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1,
                             size_t vl);
-vuint16m2_t __riscv_vwabdau(vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2,
+vuint16m2_t __riscv_vwabdau(vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1,
                             size_t vl);
-vuint16m4_t __riscv_vwabdau(vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2,
+vuint16m4_t __riscv_vwabdau(vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1,
                             size_t vl);
-vuint16m8_t __riscv_vwabdau(vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2,
+vuint16m8_t __riscv_vwabdau(vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1,
                             size_t vl);
-vuint32mf2_t __riscv_vwabdau(vuint32mf2_t vd, vuint16mf4_t vs1,
-                             vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau(vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2,
+vuint32mf2_t __riscv_vwabdau(vuint32mf2_t vd, vuint16mf4_t vs2,
+                             vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau(vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1,
                             size_t vl);
-vuint32m2_t __riscv_vwabdau(vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2,
+vuint32m2_t __riscv_vwabdau(vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1,
                             size_t vl);
-vuint32m4_t __riscv_vwabdau(vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2,
+vuint32m4_t __riscv_vwabdau(vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1,
                             size_t vl);
-vuint32m8_t __riscv_vwabdau(vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2,
+vuint32m8_t __riscv_vwabdau(vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1,
                             size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabdau(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1,
-                             vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1,
-                             vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1,
-                            vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                            vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                            vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                            vuint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabdau(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1,
-                             vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1,
-                            vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1,
-                            vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1,
-                            vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1,
-                            vuint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2,
+                             vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2,
+                             vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2,
+                            vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                            vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                            vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                            vuint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabdau(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2,
+                             vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2,
+                            vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2,
+                            vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2,
+                            vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2,
+                            vuint16m4_t vs1, size_t vl);
 ----

--- a/auto-generated/policy_funcs/api-testing/vwabda.c
+++ b/auto-generated/policy_funcs/api-testing/vwabda.c
@@ -1,242 +1,242 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs1,
-                                      vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs2,
+                                      vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs1,
-                                      vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs2,
+                                      vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs1,
-                                    vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs2,
+                                    vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs1,
-                                      vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs2,
+                                      vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs1,
-                                    vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs2,
+                                    vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs1,
-                                    vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs2,
+                                    vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_tu(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                       vint8mf8_t vs1, vint8mf8_t vs2,
+                                       vint8mf8_t vs2, vint8mf8_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                       vint8mf4_t vs1, vint8mf4_t vs2,
+                                       vint8mf4_t vs2, vint8mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                     vint8mf2_t vs1, vint8mf2_t vs2,
+                                     vint8mf2_t vs2, vint8mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u16m1_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                     vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_tum(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                     vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                     vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_tum(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                     vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                     vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_tum(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                     vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                       vint16mf4_t vs1, vint16mf4_t vs2,
+                                       vint16mf4_t vs2, vint16mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                     vint16mf2_t vs1, vint16mf2_t vs2,
+                                     vint16mf2_t vs2, vint16mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32m1_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                     vint16m1_t vs1, vint16m1_t vs2,
+                                     vint16m1_t vs2, vint16m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32m2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                     vint16m2_t vs1, vint16m2_t vs2,
+                                     vint16m2_t vs2, vint16m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32m4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                     vint16m4_t vs1, vint16m4_t vs2,
+                                     vint16m4_t vs2, vint16m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32m8_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                        vint8mf8_t vs1, vint8mf8_t vs2,
+                                        vint8mf8_t vs2, vint8mf8_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                        vint8mf4_t vs1, vint8mf4_t vs2,
+                                        vint8mf4_t vs2, vint8mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                      vint8mf2_t vs1, vint8mf2_t vs2,
+                                      vint8mf2_t vs2, vint8mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u16m1_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                      vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                      vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                      vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                        vint16mf4_t vs1, vint16mf4_t vs2,
+                                        vint16mf4_t vs2, vint16mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                      vint16mf2_t vs1, vint16mf2_t vs2,
+                                      vint16mf2_t vs2, vint16mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32m1_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                      vint16m1_t vs1, vint16m1_t vs2,
+                                      vint16m1_t vs2, vint16m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32m2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                      vint16m2_t vs1, vint16m2_t vs2,
+                                      vint16m2_t vs2, vint16m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32m4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                      vint16m4_t vs1, vint16m4_t vs2,
+                                      vint16m4_t vs2, vint16m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32m8_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                      vint8mf8_t vs1, vint8mf8_t vs2,
+                                      vint8mf8_t vs2, vint8mf8_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                      vint8mf4_t vs1, vint8mf4_t vs2,
+                                      vint8mf4_t vs2, vint8mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                    vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_mu(vm, vd, vs1, vs2, vl);
+                                    vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_mu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_mu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_mu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                      vint16mf4_t vs1, vint16mf4_t vs2,
+                                      vint16mf4_t vs2, vint16mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                    vint16mf2_t vs1, vint16mf2_t vs2,
+                                    vint16mf2_t vs2, vint16mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabda_vv_u32m1_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                    vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_mu(vm, vd, vs1, vs2, vl);
+                                    vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_mu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_mu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_mu(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vwabdau.c
+++ b/auto-generated/policy_funcs/api-testing/vwabdau.c
@@ -1,255 +1,255 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                       vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                       vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs1,
-                                     vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs1,
-                                     vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs2,
+                                     vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs1,
-                                     vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs2,
+                                     vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs1,
-                                     vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs2,
+                                     vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                       vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs1,
-                                     vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs1,
-                                     vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs2,
+                                     vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs1,
-                                     vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs2,
+                                     vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs1,
-                                     vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs2,
+                                     vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8_tu(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                        vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                        vuint8mf8_t vs2, vuint8mf8_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                        vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                        vuint8mf4_t vs2, vuint8mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                      vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                      vuint8mf2_t vs2, vuint8mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd,
-                                      vuint8m1_t vs1, vuint8m1_t vs2,
+                                      vuint8m1_t vs2, vuint8m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd,
-                                      vuint8m2_t vs1, vuint8m2_t vs2,
+                                      vuint8m2_t vs2, vuint8m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd,
-                                      vuint8m4_t vs1, vuint8m4_t vs2,
+                                      vuint8m4_t vs2, vuint8m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                        vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                        vuint16mf4_t vs2, vuint16mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                      vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                      vuint16mf2_t vs2, vuint16mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                      vuint16m1_t vs1, vuint16m1_t vs2,
+                                      vuint16m1_t vs2, vuint16m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                      vuint16m2_t vs1, vuint16m2_t vs2,
+                                      vuint16m2_t vs2, vuint16m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                      vuint16m4_t vs1, vuint16m4_t vs2,
+                                      vuint16m4_t vs2, vuint16m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                         vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                         vuint8mf8_t vs2, vuint8mf8_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                         vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                         vuint8mf4_t vs2, vuint8mf4_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                       vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                       vuint8mf2_t vs2, vuint8mf2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                       vuint8m1_t vs1, vuint8m1_t vs2,
+                                       vuint8m1_t vs2, vuint8m1_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                       vuint8m2_t vs1, vuint8m2_t vs2,
+                                       vuint8m2_t vs2, vuint8m2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                       vuint8m4_t vs1, vuint8m4_t vs2,
+                                       vuint8m4_t vs2, vuint8m4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                         vuint16mf4_t vs2, vuint16mf4_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                       vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                       vuint16mf2_t vs2, vuint16mf2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                       vuint16m1_t vs1, vuint16m1_t vs2,
+                                       vuint16m1_t vs2, vuint16m1_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                       vuint16m2_t vs1, vuint16m2_t vs2,
+                                       vuint16m2_t vs2, vuint16m2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                       vuint16m4_t vs1, vuint16m4_t vs2,
+                                       vuint16m4_t vs2, vuint16m4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                       vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs2, vuint8mf8_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                       vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs2, vuint8mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                     vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs2, vuint8mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd,
-                                     vuint8m1_t vs1, vuint8m1_t vs2,
+                                     vuint8m1_t vs2, vuint8m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd,
-                                     vuint8m2_t vs1, vuint8m2_t vs2,
+                                     vuint8m2_t vs2, vuint8m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
-                                     vuint8m4_t vs1, vuint8m4_t vs2,
+                                     vuint8m4_t vs2, vuint8m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                       vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs2, vuint16mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                     vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs2, vuint16mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                     vuint16m1_t vs1, vuint16m1_t vs2,
+                                     vuint16m1_t vs2, vuint16m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
-                                     vuint16m2_t vs1, vuint16m2_t vs2,
+                                     vuint16m2_t vs2, vuint16m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
-                                     vuint16m4_t vs1, vuint16m4_t vs2,
+                                     vuint16m4_t vs2, vuint16m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m8_mu(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/policy_funcs/gnu-api-tests/vwabda.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vwabda.c
@@ -3,179 +3,179 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_tum(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_tum(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_tum(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_tum(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_tum(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_tum(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_tum(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1_tum(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_tum(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_tum(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_tum(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_tumu(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_tumu(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_tumu(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_tumu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_tumu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_tumu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_tumu(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1_tumu(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_tumu(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_tumu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_tumu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_mu(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_mu(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_mu(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_mu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_mu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_mu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_mu(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1_mu(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_mu(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_mu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_mu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_mu(vm, vd, vs2, vs1, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vwabda\.[ivxfswum.]+\s+} 44 } } */

--- a/auto-generated/policy_funcs/gnu-api-tests/vwabdau.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vwabdau.c
@@ -3,179 +3,179 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_tum(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_tum(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_tum(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_tum(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_tum(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_tum(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_tum(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_tum(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_tum(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_tum(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_tum(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_tumu(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_tumu(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_tumu(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_tumu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_tumu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_tumu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_tumu(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_tumu(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_tumu(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_tumu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_tumu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_mu(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_mu(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_mu(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_mu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_mu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_mu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_mu(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_mu(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_mu(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_mu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_mu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8_mu(vm, vd, vs2, vs1, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vwabdau\.[ivxfswum.]+\s+} 44 } } */

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vwabda.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vwabda.c
@@ -3,179 +3,179 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1, vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2, vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vwabda\.[ivxfswum.]+\s+} 44 } } */

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vwabdau.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vwabdau.c
@@ -3,179 +3,179 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2, vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vwabdau\.[ivxfswum.]+\s+} 44 } } */

--- a/auto-generated/policy_funcs/intrinsic_funcs.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs.adoc
@@ -97354,126 +97354,126 @@ vuint16m8_t __riscv_vabdu_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs1,
-                                         vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs1,
-                                         vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs1,
-                                       vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs1,
-                                       vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs1,
-                                       vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs1,
-                                       vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs1,
-                                         vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs1,
-                                       vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs1,
-                                       vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs1,
-                                       vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs1,
-                                       vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs2,
+                                         vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs2,
+                                         vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs2,
+                                       vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs2,
+                                       vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs2,
+                                       vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs2,
+                                       vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs2,
+                                         vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs2,
+                                       vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs2,
+                                       vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs2,
+                                       vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs2,
+                                       vint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                          vint8mf8_t vs1, vint8mf8_t vs2,
+                                          vint8mf8_t vs2, vint8mf8_t vs1,
                                           size_t vl);
 vuint16mf2_t __riscv_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                          vint8mf4_t vs1, vint8mf4_t vs2,
+                                          vint8mf4_t vs2, vint8mf4_t vs1,
                                           size_t vl);
 vuint16m1_t __riscv_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                        vint8mf2_t vs1, vint8mf2_t vs2,
+                                        vint8mf2_t vs2, vint8mf2_t vs1,
                                         size_t vl);
 vuint16m2_t __riscv_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd,
-                                        vint8m1_t vs1, vint8m1_t vs2,
+                                        vint8m1_t vs2, vint8m1_t vs1,
                                         size_t vl);
 vuint16m4_t __riscv_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd,
-                                        vint8m2_t vs1, vint8m2_t vs2,
+                                        vint8m2_t vs2, vint8m2_t vs1,
                                         size_t vl);
 vuint16m8_t __riscv_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd,
-                                        vint8m4_t vs1, vint8m4_t vs2,
+                                        vint8m4_t vs2, vint8m4_t vs1,
                                         size_t vl);
 vuint32mf2_t __riscv_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                          vint16mf4_t vs1, vint16mf4_t vs2,
+                                          vint16mf4_t vs2, vint16mf4_t vs1,
                                           size_t vl);
 vuint32m1_t __riscv_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                        vint16mf2_t vs1, vint16mf2_t vs2,
+                                        vint16mf2_t vs2, vint16mf2_t vs1,
                                         size_t vl);
 vuint32m2_t __riscv_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                        vint16m1_t vs1, vint16m1_t vs2,
+                                        vint16m1_t vs2, vint16m1_t vs1,
                                         size_t vl);
 vuint32m4_t __riscv_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                        vint16m2_t vs1, vint16m2_t vs2,
+                                        vint16m2_t vs2, vint16m2_t vs1,
                                         size_t vl);
 vuint32m8_t __riscv_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                        vint16m4_t vs1, vint16m4_t vs2,
+                                        vint16m4_t vs2, vint16m4_t vs1,
                                         size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                           vint8mf8_t vs1, vint8mf8_t vs2,
+                                           vint8mf8_t vs2, vint8mf8_t vs1,
                                            size_t vl);
 vuint16mf2_t __riscv_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                           vint8mf4_t vs1, vint8mf4_t vs2,
+                                           vint8mf4_t vs2, vint8mf4_t vs1,
                                            size_t vl);
 vuint16m1_t __riscv_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                         vint8mf2_t vs1, vint8mf2_t vs2,
+                                         vint8mf2_t vs2, vint8mf2_t vs1,
                                          size_t vl);
 vuint16m2_t __riscv_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                         vint8m1_t vs1, vint8m1_t vs2,
+                                         vint8m1_t vs2, vint8m1_t vs1,
                                          size_t vl);
 vuint16m4_t __riscv_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                         vint8m2_t vs1, vint8m2_t vs2,
+                                         vint8m2_t vs2, vint8m2_t vs1,
                                          size_t vl);
 vuint16m8_t __riscv_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                         vint8m4_t vs1, vint8m4_t vs2,
+                                         vint8m4_t vs2, vint8m4_t vs1,
                                          size_t vl);
 vuint32mf2_t __riscv_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                           vint16mf4_t vs1, vint16mf4_t vs2,
+                                           vint16mf4_t vs2, vint16mf4_t vs1,
                                            size_t vl);
 vuint32m1_t __riscv_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                         vint16mf2_t vs1, vint16mf2_t vs2,
+                                         vint16mf2_t vs2, vint16mf2_t vs1,
                                          size_t vl);
 vuint32m2_t __riscv_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                         vint16m1_t vs1, vint16m1_t vs2,
+                                         vint16m1_t vs2, vint16m1_t vs1,
                                          size_t vl);
 vuint32m4_t __riscv_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                         vint16m2_t vs1, vint16m2_t vs2,
+                                         vint16m2_t vs2, vint16m2_t vs1,
                                          size_t vl);
 vuint32m8_t __riscv_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                         vint16m4_t vs1, vint16m4_t vs2,
+                                         vint16m4_t vs2, vint16m4_t vs1,
                                          size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                         vint8mf8_t vs1, vint8mf8_t vs2,
+                                         vint8mf8_t vs2, vint8mf8_t vs1,
                                          size_t vl);
 vuint16mf2_t __riscv_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                         vint8mf4_t vs1, vint8mf4_t vs2,
+                                         vint8mf4_t vs2, vint8mf4_t vs1,
                                          size_t vl);
 vuint16m1_t __riscv_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                       vint8mf2_t vs1, vint8mf2_t vs2,
+                                       vint8mf2_t vs2, vint8mf2_t vs1,
                                        size_t vl);
 vuint16m2_t __riscv_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd,
-                                       vint8m1_t vs1, vint8m1_t vs2, size_t vl);
+                                       vint8m1_t vs2, vint8m1_t vs1, size_t vl);
 vuint16m4_t __riscv_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd,
-                                       vint8m2_t vs1, vint8m2_t vs2, size_t vl);
+                                       vint8m2_t vs2, vint8m2_t vs1, size_t vl);
 vuint16m8_t __riscv_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
-                                       vint8m4_t vs1, vint8m4_t vs2, size_t vl);
+                                       vint8m4_t vs2, vint8m4_t vs1, size_t vl);
 vuint32mf2_t __riscv_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                         vint16mf4_t vs1, vint16mf4_t vs2,
+                                         vint16mf4_t vs2, vint16mf4_t vs1,
                                          size_t vl);
 vuint32m1_t __riscv_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                       vint16mf2_t vs1, vint16mf2_t vs2,
+                                       vint16mf2_t vs2, vint16mf2_t vs1,
                                        size_t vl);
 vuint32m2_t __riscv_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                       vint16m1_t vs1, vint16m1_t vs2,
+                                       vint16m1_t vs2, vint16m1_t vs1,
                                        size_t vl);
 vuint32m4_t __riscv_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
-                                       vint16m2_t vs1, vint16m2_t vs2,
+                                       vint16m2_t vs2, vint16m2_t vs1,
                                        size_t vl);
 vuint32m8_t __riscv_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
-                                       vint16m4_t vs1, vint16m4_t vs2,
+                                       vint16m4_t vs2, vint16m4_t vs1,
                                        size_t vl);
 ----
 
@@ -97482,129 +97482,129 @@ vuint32m8_t __riscv_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                          vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                          vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs1,
-                                        vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs1,
-                                        vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs1,
-                                        vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs1,
-                                        vuint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                          vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs1,
-                                        vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs1,
-                                        vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs1,
-                                        vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs1,
-                                        vuint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                          vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                          vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs2,
+                                        vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs2,
+                                        vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs2,
+                                        vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs2,
+                                        vuint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                          vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs2,
+                                        vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs2,
+                                        vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs2,
+                                        vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs2,
+                                        vuint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                           vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                           vuint8mf8_t vs2, vuint8mf8_t vs1,
                                            size_t vl);
 vuint16mf2_t __riscv_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                           vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                           vuint8mf4_t vs2, vuint8mf4_t vs1,
                                            size_t vl);
 vuint16m1_t __riscv_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                         vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                         vuint8mf2_t vs2, vuint8mf2_t vs1,
                                          size_t vl);
 vuint16m2_t __riscv_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd,
-                                         vuint8m1_t vs1, vuint8m1_t vs2,
+                                         vuint8m1_t vs2, vuint8m1_t vs1,
                                          size_t vl);
 vuint16m4_t __riscv_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd,
-                                         vuint8m2_t vs1, vuint8m2_t vs2,
+                                         vuint8m2_t vs2, vuint8m2_t vs1,
                                          size_t vl);
 vuint16m8_t __riscv_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd,
-                                         vuint8m4_t vs1, vuint8m4_t vs2,
+                                         vuint8m4_t vs2, vuint8m4_t vs1,
                                          size_t vl);
 vuint32mf2_t __riscv_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                           vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                           vuint16mf4_t vs2, vuint16mf4_t vs1,
                                            size_t vl);
 vuint32m1_t __riscv_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                         vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                         vuint16mf2_t vs2, vuint16mf2_t vs1,
                                          size_t vl);
 vuint32m2_t __riscv_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                         vuint16m1_t vs1, vuint16m1_t vs2,
+                                         vuint16m1_t vs2, vuint16m1_t vs1,
                                          size_t vl);
 vuint32m4_t __riscv_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                         vuint16m2_t vs1, vuint16m2_t vs2,
+                                         vuint16m2_t vs2, vuint16m2_t vs1,
                                          size_t vl);
 vuint32m8_t __riscv_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                         vuint16m4_t vs1, vuint16m4_t vs2,
+                                         vuint16m4_t vs2, vuint16m4_t vs1,
                                          size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                            vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                            vuint8mf8_t vs2, vuint8mf8_t vs1,
                                             size_t vl);
 vuint16mf2_t __riscv_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                            vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                            vuint8mf4_t vs2, vuint8mf4_t vs1,
                                             size_t vl);
 vuint16m1_t __riscv_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                          vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                          vuint8mf2_t vs2, vuint8mf2_t vs1,
                                           size_t vl);
 vuint16m2_t __riscv_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                          vuint8m1_t vs1, vuint8m1_t vs2,
+                                          vuint8m1_t vs2, vuint8m1_t vs1,
                                           size_t vl);
 vuint16m4_t __riscv_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                          vuint8m2_t vs1, vuint8m2_t vs2,
+                                          vuint8m2_t vs2, vuint8m2_t vs1,
                                           size_t vl);
 vuint16m8_t __riscv_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                          vuint8m4_t vs1, vuint8m4_t vs2,
+                                          vuint8m4_t vs2, vuint8m4_t vs1,
                                           size_t vl);
 vuint32mf2_t __riscv_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                            vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                            vuint16mf4_t vs2, vuint16mf4_t vs1,
                                             size_t vl);
 vuint32m1_t __riscv_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                          vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                          vuint16mf2_t vs2, vuint16mf2_t vs1,
                                           size_t vl);
 vuint32m2_t __riscv_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                          vuint16m1_t vs1, vuint16m1_t vs2,
+                                          vuint16m1_t vs2, vuint16m1_t vs1,
                                           size_t vl);
 vuint32m4_t __riscv_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                          vuint16m2_t vs1, vuint16m2_t vs2,
+                                          vuint16m2_t vs2, vuint16m2_t vs1,
                                           size_t vl);
 vuint32m8_t __riscv_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                          vuint16m4_t vs1, vuint16m4_t vs2,
+                                          vuint16m4_t vs2, vuint16m4_t vs1,
                                           size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                          vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                          vuint8mf8_t vs2, vuint8mf8_t vs1,
                                           size_t vl);
 vuint16mf2_t __riscv_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                          vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                          vuint8mf4_t vs2, vuint8mf4_t vs1,
                                           size_t vl);
 vuint16m1_t __riscv_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                        vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                        vuint8mf2_t vs2, vuint8mf2_t vs1,
                                         size_t vl);
 vuint16m2_t __riscv_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd,
-                                        vuint8m1_t vs1, vuint8m1_t vs2,
+                                        vuint8m1_t vs2, vuint8m1_t vs1,
                                         size_t vl);
 vuint16m4_t __riscv_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd,
-                                        vuint8m2_t vs1, vuint8m2_t vs2,
+                                        vuint8m2_t vs2, vuint8m2_t vs1,
                                         size_t vl);
 vuint16m8_t __riscv_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
-                                        vuint8m4_t vs1, vuint8m4_t vs2,
+                                        vuint8m4_t vs2, vuint8m4_t vs1,
                                         size_t vl);
 vuint32mf2_t __riscv_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                          vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                          vuint16mf4_t vs2, vuint16mf4_t vs1,
                                           size_t vl);
 vuint32m1_t __riscv_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                        vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                        vuint16mf2_t vs2, vuint16mf2_t vs1,
                                         size_t vl);
 vuint32m2_t __riscv_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                        vuint16m1_t vs1, vuint16m1_t vs2,
+                                        vuint16m1_t vs2, vuint16m1_t vs1,
                                         size_t vl);
 vuint32m4_t __riscv_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
-                                        vuint16m2_t vs1, vuint16m2_t vs2,
+                                        vuint16m2_t vs2, vuint16m2_t vs1,
                                         size_t vl);
 vuint32m8_t __riscv_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
-                                        vuint16m4_t vs1, vuint16m4_t vs2,
+                                        vuint16m4_t vs2, vuint16m4_t vs1,
                                         size_t vl);
 ----
 

--- a/auto-generated/policy_funcs/intrinsic_funcs/14_zvabd_-_vector_absolute_difference_instructions.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/14_zvabd_-_vector_absolute_difference_instructions.adoc
@@ -452,126 +452,126 @@ vuint16m8_t __riscv_vabdu_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs1,
-                                         vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs1,
-                                         vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs1,
-                                       vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs1,
-                                       vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs1,
-                                       vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs1,
-                                       vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs1,
-                                         vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs1,
-                                       vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs1,
-                                       vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs1,
-                                       vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs1,
-                                       vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs2,
+                                         vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs2,
+                                         vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs2,
+                                       vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs2,
+                                       vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs2,
+                                       vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs2,
+                                       vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs2,
+                                         vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs2,
+                                       vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs2,
+                                       vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs2,
+                                       vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs2,
+                                       vint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                          vint8mf8_t vs1, vint8mf8_t vs2,
+                                          vint8mf8_t vs2, vint8mf8_t vs1,
                                           size_t vl);
 vuint16mf2_t __riscv_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                          vint8mf4_t vs1, vint8mf4_t vs2,
+                                          vint8mf4_t vs2, vint8mf4_t vs1,
                                           size_t vl);
 vuint16m1_t __riscv_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                        vint8mf2_t vs1, vint8mf2_t vs2,
+                                        vint8mf2_t vs2, vint8mf2_t vs1,
                                         size_t vl);
 vuint16m2_t __riscv_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd,
-                                        vint8m1_t vs1, vint8m1_t vs2,
+                                        vint8m1_t vs2, vint8m1_t vs1,
                                         size_t vl);
 vuint16m4_t __riscv_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd,
-                                        vint8m2_t vs1, vint8m2_t vs2,
+                                        vint8m2_t vs2, vint8m2_t vs1,
                                         size_t vl);
 vuint16m8_t __riscv_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd,
-                                        vint8m4_t vs1, vint8m4_t vs2,
+                                        vint8m4_t vs2, vint8m4_t vs1,
                                         size_t vl);
 vuint32mf2_t __riscv_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                          vint16mf4_t vs1, vint16mf4_t vs2,
+                                          vint16mf4_t vs2, vint16mf4_t vs1,
                                           size_t vl);
 vuint32m1_t __riscv_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                        vint16mf2_t vs1, vint16mf2_t vs2,
+                                        vint16mf2_t vs2, vint16mf2_t vs1,
                                         size_t vl);
 vuint32m2_t __riscv_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                        vint16m1_t vs1, vint16m1_t vs2,
+                                        vint16m1_t vs2, vint16m1_t vs1,
                                         size_t vl);
 vuint32m4_t __riscv_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                        vint16m2_t vs1, vint16m2_t vs2,
+                                        vint16m2_t vs2, vint16m2_t vs1,
                                         size_t vl);
 vuint32m8_t __riscv_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                        vint16m4_t vs1, vint16m4_t vs2,
+                                        vint16m4_t vs2, vint16m4_t vs1,
                                         size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                           vint8mf8_t vs1, vint8mf8_t vs2,
+                                           vint8mf8_t vs2, vint8mf8_t vs1,
                                            size_t vl);
 vuint16mf2_t __riscv_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                           vint8mf4_t vs1, vint8mf4_t vs2,
+                                           vint8mf4_t vs2, vint8mf4_t vs1,
                                            size_t vl);
 vuint16m1_t __riscv_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                         vint8mf2_t vs1, vint8mf2_t vs2,
+                                         vint8mf2_t vs2, vint8mf2_t vs1,
                                          size_t vl);
 vuint16m2_t __riscv_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                         vint8m1_t vs1, vint8m1_t vs2,
+                                         vint8m1_t vs2, vint8m1_t vs1,
                                          size_t vl);
 vuint16m4_t __riscv_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                         vint8m2_t vs1, vint8m2_t vs2,
+                                         vint8m2_t vs2, vint8m2_t vs1,
                                          size_t vl);
 vuint16m8_t __riscv_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                         vint8m4_t vs1, vint8m4_t vs2,
+                                         vint8m4_t vs2, vint8m4_t vs1,
                                          size_t vl);
 vuint32mf2_t __riscv_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                           vint16mf4_t vs1, vint16mf4_t vs2,
+                                           vint16mf4_t vs2, vint16mf4_t vs1,
                                            size_t vl);
 vuint32m1_t __riscv_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                         vint16mf2_t vs1, vint16mf2_t vs2,
+                                         vint16mf2_t vs2, vint16mf2_t vs1,
                                          size_t vl);
 vuint32m2_t __riscv_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                         vint16m1_t vs1, vint16m1_t vs2,
+                                         vint16m1_t vs2, vint16m1_t vs1,
                                          size_t vl);
 vuint32m4_t __riscv_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                         vint16m2_t vs1, vint16m2_t vs2,
+                                         vint16m2_t vs2, vint16m2_t vs1,
                                          size_t vl);
 vuint32m8_t __riscv_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                         vint16m4_t vs1, vint16m4_t vs2,
+                                         vint16m4_t vs2, vint16m4_t vs1,
                                          size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                         vint8mf8_t vs1, vint8mf8_t vs2,
+                                         vint8mf8_t vs2, vint8mf8_t vs1,
                                          size_t vl);
 vuint16mf2_t __riscv_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                         vint8mf4_t vs1, vint8mf4_t vs2,
+                                         vint8mf4_t vs2, vint8mf4_t vs1,
                                          size_t vl);
 vuint16m1_t __riscv_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                       vint8mf2_t vs1, vint8mf2_t vs2,
+                                       vint8mf2_t vs2, vint8mf2_t vs1,
                                        size_t vl);
 vuint16m2_t __riscv_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd,
-                                       vint8m1_t vs1, vint8m1_t vs2, size_t vl);
+                                       vint8m1_t vs2, vint8m1_t vs1, size_t vl);
 vuint16m4_t __riscv_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd,
-                                       vint8m2_t vs1, vint8m2_t vs2, size_t vl);
+                                       vint8m2_t vs2, vint8m2_t vs1, size_t vl);
 vuint16m8_t __riscv_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
-                                       vint8m4_t vs1, vint8m4_t vs2, size_t vl);
+                                       vint8m4_t vs2, vint8m4_t vs1, size_t vl);
 vuint32mf2_t __riscv_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                         vint16mf4_t vs1, vint16mf4_t vs2,
+                                         vint16mf4_t vs2, vint16mf4_t vs1,
                                          size_t vl);
 vuint32m1_t __riscv_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                       vint16mf2_t vs1, vint16mf2_t vs2,
+                                       vint16mf2_t vs2, vint16mf2_t vs1,
                                        size_t vl);
 vuint32m2_t __riscv_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                       vint16m1_t vs1, vint16m1_t vs2,
+                                       vint16m1_t vs2, vint16m1_t vs1,
                                        size_t vl);
 vuint32m4_t __riscv_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
-                                       vint16m2_t vs1, vint16m2_t vs2,
+                                       vint16m2_t vs2, vint16m2_t vs1,
                                        size_t vl);
 vuint32m8_t __riscv_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
-                                       vint16m4_t vs1, vint16m4_t vs2,
+                                       vint16m4_t vs2, vint16m4_t vs1,
                                        size_t vl);
 ----
 
@@ -580,128 +580,128 @@ vuint32m8_t __riscv_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                          vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                          vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs1,
-                                        vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs1,
-                                        vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs1,
-                                        vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs1,
-                                        vuint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                          vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs1,
-                                        vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs1,
-                                        vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs1,
-                                        vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs1,
-                                        vuint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                          vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                          vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs2,
+                                        vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs2,
+                                        vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs2,
+                                        vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs2,
+                                        vuint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                          vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs2,
+                                        vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs2,
+                                        vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs2,
+                                        vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs2,
+                                        vuint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                           vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                           vuint8mf8_t vs2, vuint8mf8_t vs1,
                                            size_t vl);
 vuint16mf2_t __riscv_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                           vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                           vuint8mf4_t vs2, vuint8mf4_t vs1,
                                            size_t vl);
 vuint16m1_t __riscv_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                         vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                         vuint8mf2_t vs2, vuint8mf2_t vs1,
                                          size_t vl);
 vuint16m2_t __riscv_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd,
-                                         vuint8m1_t vs1, vuint8m1_t vs2,
+                                         vuint8m1_t vs2, vuint8m1_t vs1,
                                          size_t vl);
 vuint16m4_t __riscv_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd,
-                                         vuint8m2_t vs1, vuint8m2_t vs2,
+                                         vuint8m2_t vs2, vuint8m2_t vs1,
                                          size_t vl);
 vuint16m8_t __riscv_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd,
-                                         vuint8m4_t vs1, vuint8m4_t vs2,
+                                         vuint8m4_t vs2, vuint8m4_t vs1,
                                          size_t vl);
 vuint32mf2_t __riscv_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                           vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                           vuint16mf4_t vs2, vuint16mf4_t vs1,
                                            size_t vl);
 vuint32m1_t __riscv_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                         vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                         vuint16mf2_t vs2, vuint16mf2_t vs1,
                                          size_t vl);
 vuint32m2_t __riscv_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                         vuint16m1_t vs1, vuint16m1_t vs2,
+                                         vuint16m1_t vs2, vuint16m1_t vs1,
                                          size_t vl);
 vuint32m4_t __riscv_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                         vuint16m2_t vs1, vuint16m2_t vs2,
+                                         vuint16m2_t vs2, vuint16m2_t vs1,
                                          size_t vl);
 vuint32m8_t __riscv_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                         vuint16m4_t vs1, vuint16m4_t vs2,
+                                         vuint16m4_t vs2, vuint16m4_t vs1,
                                          size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                            vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                            vuint8mf8_t vs2, vuint8mf8_t vs1,
                                             size_t vl);
 vuint16mf2_t __riscv_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                            vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                            vuint8mf4_t vs2, vuint8mf4_t vs1,
                                             size_t vl);
 vuint16m1_t __riscv_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                          vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                          vuint8mf2_t vs2, vuint8mf2_t vs1,
                                           size_t vl);
 vuint16m2_t __riscv_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                          vuint8m1_t vs1, vuint8m1_t vs2,
+                                          vuint8m1_t vs2, vuint8m1_t vs1,
                                           size_t vl);
 vuint16m4_t __riscv_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                          vuint8m2_t vs1, vuint8m2_t vs2,
+                                          vuint8m2_t vs2, vuint8m2_t vs1,
                                           size_t vl);
 vuint16m8_t __riscv_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                          vuint8m4_t vs1, vuint8m4_t vs2,
+                                          vuint8m4_t vs2, vuint8m4_t vs1,
                                           size_t vl);
 vuint32mf2_t __riscv_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                            vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                            vuint16mf4_t vs2, vuint16mf4_t vs1,
                                             size_t vl);
 vuint32m1_t __riscv_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                          vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                          vuint16mf2_t vs2, vuint16mf2_t vs1,
                                           size_t vl);
 vuint32m2_t __riscv_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                          vuint16m1_t vs1, vuint16m1_t vs2,
+                                          vuint16m1_t vs2, vuint16m1_t vs1,
                                           size_t vl);
 vuint32m4_t __riscv_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                          vuint16m2_t vs1, vuint16m2_t vs2,
+                                          vuint16m2_t vs2, vuint16m2_t vs1,
                                           size_t vl);
 vuint32m8_t __riscv_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                          vuint16m4_t vs1, vuint16m4_t vs2,
+                                          vuint16m4_t vs2, vuint16m4_t vs1,
                                           size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                          vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                          vuint8mf8_t vs2, vuint8mf8_t vs1,
                                           size_t vl);
 vuint16mf2_t __riscv_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                          vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                          vuint8mf4_t vs2, vuint8mf4_t vs1,
                                           size_t vl);
 vuint16m1_t __riscv_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                        vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                        vuint8mf2_t vs2, vuint8mf2_t vs1,
                                         size_t vl);
 vuint16m2_t __riscv_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd,
-                                        vuint8m1_t vs1, vuint8m1_t vs2,
+                                        vuint8m1_t vs2, vuint8m1_t vs1,
                                         size_t vl);
 vuint16m4_t __riscv_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd,
-                                        vuint8m2_t vs1, vuint8m2_t vs2,
+                                        vuint8m2_t vs2, vuint8m2_t vs1,
                                         size_t vl);
 vuint16m8_t __riscv_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
-                                        vuint8m4_t vs1, vuint8m4_t vs2,
+                                        vuint8m4_t vs2, vuint8m4_t vs1,
                                         size_t vl);
 vuint32mf2_t __riscv_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                          vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                          vuint16mf4_t vs2, vuint16mf4_t vs1,
                                           size_t vl);
 vuint32m1_t __riscv_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                        vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                        vuint16mf2_t vs2, vuint16mf2_t vs1,
                                         size_t vl);
 vuint32m2_t __riscv_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                        vuint16m1_t vs1, vuint16m1_t vs2,
+                                        vuint16m1_t vs2, vuint16m1_t vs1,
                                         size_t vl);
 vuint32m4_t __riscv_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
-                                        vuint16m2_t vs1, vuint16m2_t vs2,
+                                        vuint16m2_t vs2, vuint16m2_t vs1,
                                         size_t vl);
 vuint32m8_t __riscv_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
-                                        vuint16m4_t vs1, vuint16m4_t vs2,
+                                        vuint16m4_t vs2, vuint16m4_t vs1,
                                         size_t vl);
 ----

--- a/auto-generated/policy_funcs/llvm-api-tests/vwabda.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vwabda.c
@@ -7,242 +7,242 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs1,
-                                      vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs2,
+                                      vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs1,
-                                      vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs2,
+                                      vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs1,
-                                    vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs2,
+                                    vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs1,
-                                      vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs2,
+                                      vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs1,
-                                    vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m1_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs2,
+                                    vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs1,
-                                    vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs2,
+                                    vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_tu(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                       vint8mf8_t vs1, vint8mf8_t vs2,
+                                       vint8mf8_t vs2, vint8mf8_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                       vint8mf4_t vs1, vint8mf4_t vs2,
+                                       vint8mf4_t vs2, vint8mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                     vint8mf2_t vs1, vint8mf2_t vs2,
+                                     vint8mf2_t vs2, vint8mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u16m1_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                     vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_tum(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                     vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                     vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_tum(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                     vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                     vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_tum(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                     vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                       vint16mf4_t vs1, vint16mf4_t vs2,
+                                       vint16mf4_t vs2, vint16mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                     vint16mf2_t vs1, vint16mf2_t vs2,
+                                     vint16mf2_t vs2, vint16mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32m1_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                     vint16m1_t vs1, vint16m1_t vs2,
+                                     vint16m1_t vs2, vint16m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32m2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                     vint16m2_t vs1, vint16m2_t vs2,
+                                     vint16m2_t vs2, vint16m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32m4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                     vint16m4_t vs1, vint16m4_t vs2,
+                                     vint16m4_t vs2, vint16m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_vv_u32m8_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                        vint8mf8_t vs1, vint8mf8_t vs2,
+                                        vint8mf8_t vs2, vint8mf8_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                        vint8mf4_t vs1, vint8mf4_t vs2,
+                                        vint8mf4_t vs2, vint8mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                      vint8mf2_t vs1, vint8mf2_t vs2,
+                                      vint8mf2_t vs2, vint8mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u16m1_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                      vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                      vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                      vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                        vint16mf4_t vs1, vint16mf4_t vs2,
+                                        vint16mf4_t vs2, vint16mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                      vint16mf2_t vs1, vint16mf2_t vs2,
+                                      vint16mf2_t vs2, vint16mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32m1_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                      vint16m1_t vs1, vint16m1_t vs2,
+                                      vint16m1_t vs2, vint16m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32m2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                      vint16m2_t vs1, vint16m2_t vs2,
+                                      vint16m2_t vs2, vint16m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32m4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                      vint16m4_t vs1, vint16m4_t vs2,
+                                      vint16m4_t vs2, vint16m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32m8_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                      vint8mf8_t vs1, vint8mf8_t vs2,
+                                      vint8mf8_t vs2, vint8mf8_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u16mf4_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                      vint8mf4_t vs1, vint8mf4_t vs2,
+                                      vint8mf4_t vs2, vint8mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u16mf2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                    vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m1_mu(vm, vd, vs1, vs2, vl);
+                                    vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m2_mu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m4_mu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u16m8_mu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                      vint16mf4_t vs1, vint16mf4_t vs2,
+                                      vint16mf4_t vs2, vint16mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_vv_u32mf2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                    vint16mf2_t vs1, vint16mf2_t vs2,
+                                    vint16mf2_t vs2, vint16mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabda_vv_u32m1_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_vv_u32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                    vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m2_mu(vm, vd, vs1, vs2, vl);
+                                    vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m4_mu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_vv_u32m8_mu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_vv_u32m8_mu(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/policy_funcs/llvm-api-tests/vwabdau.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vwabdau.c
@@ -7,255 +7,255 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                       vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                       vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs1,
-                                     vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs1,
-                                     vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs2,
+                                     vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs1,
-                                     vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs2,
+                                     vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs1,
-                                     vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs2,
+                                     vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u16m8_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                       vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32mf2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs1,
-                                     vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m1_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs1,
-                                     vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs2,
+                                     vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m2_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs1,
-                                     vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs2,
+                                     vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m4_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs1,
-                                     vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs2,
+                                     vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_vv_u32m8_tu(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                        vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                        vuint8mf8_t vs2, vuint8mf8_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                        vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                        vuint8mf4_t vs2, vuint8mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                      vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                      vuint8mf2_t vs2, vuint8mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m1_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd,
-                                      vuint8m1_t vs1, vuint8m1_t vs2,
+                                      vuint8m1_t vs2, vuint8m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd,
-                                      vuint8m2_t vs1, vuint8m2_t vs2,
+                                      vuint8m2_t vs2, vuint8m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd,
-                                      vuint8m4_t vs1, vuint8m4_t vs2,
+                                      vuint8m4_t vs2, vuint8m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                        vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                        vuint16mf4_t vs2, vuint16mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                      vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                      vuint16mf2_t vs2, vuint16mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                      vuint16m1_t vs1, vuint16m1_t vs2,
+                                      vuint16m1_t vs2, vuint16m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                      vuint16m2_t vs1, vuint16m2_t vs2,
+                                      vuint16m2_t vs2, vuint16m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                      vuint16m4_t vs1, vuint16m4_t vs2,
+                                      vuint16m4_t vs2, vuint16m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                         vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                         vuint8mf8_t vs2, vuint8mf8_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                         vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                         vuint8mf4_t vs2, vuint8mf4_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                       vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                       vuint8mf2_t vs2, vuint8mf2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                       vuint8m1_t vs1, vuint8m1_t vs2,
+                                       vuint8m1_t vs2, vuint8m1_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                       vuint8m2_t vs1, vuint8m2_t vs2,
+                                       vuint8m2_t vs2, vuint8m2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                       vuint8m4_t vs1, vuint8m4_t vs2,
+                                       vuint8m4_t vs2, vuint8m4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                         vuint16mf4_t vs2, vuint16mf4_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                       vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                       vuint16mf2_t vs2, vuint16mf2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                       vuint16m1_t vs1, vuint16m1_t vs2,
+                                       vuint16m1_t vs2, vuint16m1_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                       vuint16m2_t vs1, vuint16m2_t vs2,
+                                       vuint16m2_t vs2, vuint16m2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                       vuint16m4_t vs1, vuint16m4_t vs2,
+                                       vuint16m4_t vs2, vuint16m4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                       vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs2, vuint8mf8_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16mf4_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf4_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                       vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs2, vuint8mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u16mf2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                     vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs2, vuint8mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u16m1_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m1_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd,
-                                     vuint8m1_t vs1, vuint8m1_t vs2,
+                                     vuint8m1_t vs2, vuint8m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u16m2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd,
-                                     vuint8m2_t vs1, vuint8m2_t vs2,
+                                     vuint8m2_t vs2, vuint8m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u16m4_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m4_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
-                                     vuint8m4_t vs1, vuint8m4_t vs2,
+                                     vuint8m4_t vs2, vuint8m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u16m8_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u16m8_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                       vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs2, vuint16mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_vv_u32mf2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                     vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs2, vuint16mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u32m1_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                     vuint16m1_t vs1, vuint16m1_t vs2,
+                                     vuint16m1_t vs2, vuint16m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u32m2_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
-                                     vuint16m2_t vs1, vuint16m2_t vs2,
+                                     vuint16m2_t vs2, vuint16m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u32m4_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
-                                     vuint16m4_t vs1, vuint16m4_t vs2,
+                                     vuint16m4_t vs2, vuint16m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_vv_u32m8_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_vv_u32m8_mu(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vwabda.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vwabda.c
@@ -7,242 +7,242 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs1,
-                                      vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs2,
+                                      vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs1,
-                                      vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs2,
+                                      vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs1,
-                                    vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs2,
+                                    vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs1,
-                                      vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs2,
+                                      vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs1,
-                                    vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs2,
+                                    vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs1,
-                                    vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs2,
+                                    vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                       vint8mf8_t vs1, vint8mf8_t vs2,
+                                       vint8mf8_t vs2, vint8mf8_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                       vint8mf4_t vs1, vint8mf4_t vs2,
+                                       vint8mf4_t vs2, vint8mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                     vint8mf2_t vs1, vint8mf2_t vs2,
+                                     vint8mf2_t vs2, vint8mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                     vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                     vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                     vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                     vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                     vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                     vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                       vint16mf4_t vs1, vint16mf4_t vs2,
+                                       vint16mf4_t vs2, vint16mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                     vint16mf2_t vs1, vint16mf2_t vs2,
+                                     vint16mf2_t vs2, vint16mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                     vint16m1_t vs1, vint16m1_t vs2,
+                                     vint16m1_t vs2, vint16m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                     vint16m2_t vs1, vint16m2_t vs2,
+                                     vint16m2_t vs2, vint16m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                     vint16m4_t vs1, vint16m4_t vs2,
+                                     vint16m4_t vs2, vint16m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                        vint8mf8_t vs1, vint8mf8_t vs2,
+                                        vint8mf8_t vs2, vint8mf8_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                        vint8mf4_t vs1, vint8mf4_t vs2,
+                                        vint8mf4_t vs2, vint8mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                      vint8mf2_t vs1, vint8mf2_t vs2,
+                                      vint8mf2_t vs2, vint8mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                      vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                      vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                      vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                        vint16mf4_t vs1, vint16mf4_t vs2,
+                                        vint16mf4_t vs2, vint16mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                      vint16mf2_t vs1, vint16mf2_t vs2,
+                                      vint16mf2_t vs2, vint16mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                      vint16m1_t vs1, vint16m1_t vs2,
+                                      vint16m1_t vs2, vint16m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                      vint16m2_t vs1, vint16m2_t vs2,
+                                      vint16m2_t vs2, vint16m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                      vint16m4_t vs1, vint16m4_t vs2,
+                                      vint16m4_t vs2, vint16m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                      vint8mf8_t vs1, vint8mf8_t vs2,
+                                      vint8mf8_t vs2, vint8mf8_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                      vint8mf4_t vs1, vint8mf4_t vs2,
+                                      vint8mf4_t vs2, vint8mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                    vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+                                    vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                      vint16mf4_t vs1, vint16mf4_t vs2,
+                                      vint16mf4_t vs2, vint16mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                    vint16mf2_t vs1, vint16mf2_t vs2,
+                                    vint16mf2_t vs2, vint16mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                    vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+                                    vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vwabdau.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vwabdau.c
@@ -7,255 +7,255 @@
 
 #include <riscv_vector.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                       vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                       vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs1,
-                                     vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs1,
-                                     vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs2,
+                                     vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs1,
-                                     vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs2,
+                                     vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs1,
-                                     vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs2,
+                                     vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                       vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs1,
-                                     vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs1,
-                                     vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs2,
+                                     vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs1,
-                                     vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs2,
+                                     vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs1,
-                                     vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs2,
+                                     vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                        vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                        vuint8mf8_t vs2, vuint8mf8_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                        vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                        vuint8mf4_t vs2, vuint8mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                      vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                      vuint8mf2_t vs2, vuint8mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd,
-                                      vuint8m1_t vs1, vuint8m1_t vs2,
+                                      vuint8m1_t vs2, vuint8m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd,
-                                      vuint8m2_t vs1, vuint8m2_t vs2,
+                                      vuint8m2_t vs2, vuint8m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd,
-                                      vuint8m4_t vs1, vuint8m4_t vs2,
+                                      vuint8m4_t vs2, vuint8m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                        vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                        vuint16mf4_t vs2, vuint16mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                      vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                      vuint16mf2_t vs2, vuint16mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                      vuint16m1_t vs1, vuint16m1_t vs2,
+                                      vuint16m1_t vs2, vuint16m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                      vuint16m2_t vs1, vuint16m2_t vs2,
+                                      vuint16m2_t vs2, vuint16m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                      vuint16m4_t vs1, vuint16m4_t vs2,
+                                      vuint16m4_t vs2, vuint16m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                         vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                         vuint8mf8_t vs2, vuint8mf8_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                         vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                         vuint8mf4_t vs2, vuint8mf4_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                       vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                       vuint8mf2_t vs2, vuint8mf2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                       vuint8m1_t vs1, vuint8m1_t vs2,
+                                       vuint8m1_t vs2, vuint8m1_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                       vuint8m2_t vs1, vuint8m2_t vs2,
+                                       vuint8m2_t vs2, vuint8m2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                       vuint8m4_t vs1, vuint8m4_t vs2,
+                                       vuint8m4_t vs2, vuint8m4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                         vuint16mf4_t vs2, vuint16mf4_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                       vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                       vuint16mf2_t vs2, vuint16mf2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                       vuint16m1_t vs1, vuint16m1_t vs2,
+                                       vuint16m1_t vs2, vuint16m1_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                       vuint16m2_t vs1, vuint16m2_t vs2,
+                                       vuint16m2_t vs2, vuint16m2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                       vuint16m4_t vs1, vuint16m4_t vs2,
+                                       vuint16m4_t vs2, vuint16m4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                       vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs2, vuint8mf8_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                       vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs2, vuint8mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                     vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs2, vuint8mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd,
-                                     vuint8m1_t vs1, vuint8m1_t vs2,
+                                     vuint8m1_t vs2, vuint8m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd,
-                                     vuint8m2_t vs1, vuint8m2_t vs2,
+                                     vuint8m2_t vs2, vuint8m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
-                                     vuint8m4_t vs1, vuint8m4_t vs2,
+                                     vuint8m4_t vs2, vuint8m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                       vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs2, vuint16mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                     vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs2, vuint16mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                     vuint16m1_t vs1, vuint16m1_t vs2,
+                                     vuint16m1_t vs2, vuint16m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
-                                     vuint16m2_t vs1, vuint16m2_t vs2,
+                                     vuint16m2_t vs2, vuint16m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
-                                     vuint16m4_t vs1, vuint16m4_t vs2,
+                                     vuint16m4_t vs2, vuint16m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vwabda.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vwabda.c
@@ -1,242 +1,242 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs1,
-                                      vint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabda_vv_u16mf4_tu(vuint16mf4_t vd, vint8mf8_t vs2,
+                                      vint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs1,
-                                      vint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabda_vv_u16mf2_tu(vuint16mf2_t vd, vint8mf4_t vs2,
+                                      vint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs1,
-                                    vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabda_vv_u16m1_tu(vuint16m1_t vd, vint8mf2_t vs2,
+                                    vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tu(vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tu(vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tu(vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs1,
-                                      vint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabda_vv_u32mf2_tu(vuint32mf2_t vd, vint16mf4_t vs2,
+                                      vint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs1,
-                                    vint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabda_vv_u32m1_tu(vuint32m1_t vd, vint16mf2_t vs2,
+                                    vint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs1,
-                                    vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabda_vv_u32m2_tu(vuint32m2_t vd, vint16m1_t vs2,
+                                    vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_tu(vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_tu(vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tu(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                       vint8mf8_t vs1, vint8mf8_t vs2,
+                                       vint8mf8_t vs2, vint8mf8_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                       vint8mf4_t vs1, vint8mf4_t vs2,
+                                       vint8mf4_t vs2, vint8mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                     vint8mf2_t vs1, vint8mf2_t vs2,
+                                     vint8mf2_t vs2, vint8mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                     vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                     vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                     vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                     vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                     vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                     vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                       vint16mf4_t vs1, vint16mf4_t vs2,
+                                       vint16mf4_t vs2, vint16mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                     vint16mf2_t vs1, vint16mf2_t vs2,
+                                     vint16mf2_t vs2, vint16mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                     vint16m1_t vs1, vint16m1_t vs2,
+                                     vint16m1_t vs2, vint16m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabda_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                     vint16m2_t vs1, vint16m2_t vs2,
+                                     vint16m2_t vs2, vint16m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabda_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                     vint16m4_t vs1, vint16m4_t vs2,
+                                     vint16m4_t vs2, vint16m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabda_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                        vint8mf8_t vs1, vint8mf8_t vs2,
+                                        vint8mf8_t vs2, vint8mf8_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                        vint8mf4_t vs1, vint8mf4_t vs2,
+                                        vint8mf4_t vs2, vint8mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                      vint8mf2_t vs1, vint8mf2_t vs2,
+                                      vint8mf2_t vs2, vint8mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabda_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                      vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabda_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                      vint8m2_t vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m2_t vs2, vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabda_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                      vint8m4_t vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+                                      vint8m4_t vs2, vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                        vint16mf4_t vs1, vint16mf4_t vs2,
+                                        vint16mf4_t vs2, vint16mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                      vint16mf2_t vs1, vint16mf2_t vs2,
+                                      vint16mf2_t vs2, vint16mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                      vint16m1_t vs1, vint16m1_t vs2,
+                                      vint16m1_t vs2, vint16m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabda_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                      vint16m2_t vs1, vint16m2_t vs2,
+                                      vint16m2_t vs2, vint16m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabda_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                      vint16m4_t vs1, vint16m4_t vs2,
+                                      vint16m4_t vs2, vint16m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabda_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                      vint8mf8_t vs1, vint8mf8_t vs2,
+                                      vint8mf8_t vs2, vint8mf8_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabda_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                      vint8mf4_t vs1, vint8mf4_t vs2,
+                                      vint8mf4_t vs2, vint8mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabda_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                    vint8mf2_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+                                    vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                    vint8m1_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m2_t test_vwabda_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                    vint8m1_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                    vint8m2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m4_t test_vwabda_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                    vint8m2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                    vint8m4_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint16m8_t test_vwabda_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                    vint8m4_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabda_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                      vint16mf4_t vs1, vint16mf4_t vs2,
+                                      vint16mf4_t vs2, vint16mf4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabda_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                    vint16mf2_t vs1, vint16mf2_t vs2,
+                                    vint16mf2_t vs2, vint16mf2_t vs1,
                                     size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabda_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                    vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+                                    vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                    vint16m2_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint32m4_t test_vwabda_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                    vint16m2_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                    vint16m4_t vs2, size_t vl) {
-  return __riscv_vwabda_mu(vm, vd, vs1, vs2, vl);
+vuint32m8_t test_vwabda_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                    vint16m4_t vs1, size_t vl) {
+  return __riscv_vwabda_mu(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vwabdau.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vwabdau.c
@@ -1,255 +1,255 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                       vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16mf4_t test_vwabdau_vv_u16mf4_tu(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                       vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16mf2_t test_vwabdau_vv_u16mf2_tu(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs1,
-                                     vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m1_t test_vwabdau_vv_u16m1_tu(vuint16m1_t vd, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs1,
-                                     vuint8m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m2_t test_vwabdau_vv_u16m2_tu(vuint16m2_t vd, vuint8m1_t vs2,
+                                     vuint8m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs1,
-                                     vuint8m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m4_t test_vwabdau_vv_u16m4_tu(vuint16m4_t vd, vuint8m2_t vs2,
+                                     vuint8m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs1,
-                                     vuint8m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint16m8_t test_vwabdau_vv_u16m8_tu(vuint16m8_t vd, vuint8m4_t vs2,
+                                     vuint8m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                       vuint16mf4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32mf2_t test_vwabdau_vv_u32mf2_tu(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs1,
-                                     vuint16mf2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m1_t test_vwabdau_vv_u32m1_tu(vuint32m1_t vd, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs1,
-                                     vuint16m1_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m2_t test_vwabdau_vv_u32m2_tu(vuint32m2_t vd, vuint16m1_t vs2,
+                                     vuint16m1_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs1,
-                                     vuint16m2_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m4_t test_vwabdau_vv_u32m4_tu(vuint32m4_t vd, vuint16m2_t vs2,
+                                     vuint16m2_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
-vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs1,
-                                     vuint16m4_t vs2, size_t vl) {
-  return __riscv_vwabdau_tu(vd, vs1, vs2, vl);
+vuint32m8_t test_vwabdau_vv_u32m8_tu(vuint32m8_t vd, vuint16m4_t vs2,
+                                     vuint16m4_t vs1, size_t vl) {
+  return __riscv_vwabdau_tu(vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_tum(vbool64_t vm, vuint16mf4_t vd,
-                                        vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                        vuint8mf8_t vs2, vuint8mf8_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_tum(vbool32_t vm, vuint16mf2_t vd,
-                                        vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                        vuint8mf4_t vs2, vuint8mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_tum(vbool16_t vm, vuint16m1_t vd,
-                                      vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                      vuint8mf2_t vs2, vuint8mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_tum(vbool8_t vm, vuint16m2_t vd,
-                                      vuint8m1_t vs1, vuint8m1_t vs2,
+                                      vuint8m1_t vs2, vuint8m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_tum(vbool4_t vm, vuint16m4_t vd,
-                                      vuint8m2_t vs1, vuint8m2_t vs2,
+                                      vuint8m2_t vs2, vuint8m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_tum(vbool2_t vm, vuint16m8_t vd,
-                                      vuint8m4_t vs1, vuint8m4_t vs2,
+                                      vuint8m4_t vs2, vuint8m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                        vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                        vuint16mf4_t vs2, vuint16mf4_t vs1,
                                         size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                      vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                      vuint16mf2_t vs2, vuint16mf2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                      vuint16m1_t vs1, vuint16m1_t vs2,
+                                      vuint16m1_t vs2, vuint16m1_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                      vuint16m2_t vs1, vuint16m2_t vs2,
+                                      vuint16m2_t vs2, vuint16m2_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                      vuint16m4_t vs1, vuint16m4_t vs2,
+                                      vuint16m4_t vs2, vuint16m4_t vs1,
                                       size_t vl) {
-  return __riscv_vwabdau_tum(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tum(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                         vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                         vuint8mf8_t vs2, vuint8mf8_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                         vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                         vuint8mf4_t vs2, vuint8mf4_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_tumu(vbool16_t vm, vuint16m1_t vd,
-                                       vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                       vuint8mf2_t vs2, vuint8mf2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_tumu(vbool8_t vm, vuint16m2_t vd,
-                                       vuint8m1_t vs1, vuint8m1_t vs2,
+                                       vuint8m1_t vs2, vuint8m1_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_tumu(vbool4_t vm, vuint16m4_t vd,
-                                       vuint8m2_t vs1, vuint8m2_t vs2,
+                                       vuint8m2_t vs2, vuint8m2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_tumu(vbool2_t vm, vuint16m8_t vd,
-                                       vuint8m4_t vs1, vuint8m4_t vs2,
+                                       vuint8m4_t vs2, vuint8m4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                         vuint16mf4_t vs2, vuint16mf4_t vs1,
                                          size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                       vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                       vuint16mf2_t vs2, vuint16mf2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                       vuint16m1_t vs1, vuint16m1_t vs2,
+                                       vuint16m1_t vs2, vuint16m1_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                       vuint16m2_t vs1, vuint16m2_t vs2,
+                                       vuint16m2_t vs2, vuint16m2_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                       vuint16m4_t vs1, vuint16m4_t vs2,
+                                       vuint16m4_t vs2, vuint16m4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_tumu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_tumu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf4_t test_vwabdau_vv_u16mf4_mu(vbool64_t vm, vuint16mf4_t vd,
-                                       vuint8mf8_t vs1, vuint8mf8_t vs2,
+                                       vuint8mf8_t vs2, vuint8mf8_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16mf2_t test_vwabdau_vv_u16mf2_mu(vbool32_t vm, vuint16mf2_t vd,
-                                       vuint8mf4_t vs1, vuint8mf4_t vs2,
+                                       vuint8mf4_t vs2, vuint8mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m1_t test_vwabdau_vv_u16m1_mu(vbool16_t vm, vuint16m1_t vd,
-                                     vuint8mf2_t vs1, vuint8mf2_t vs2,
+                                     vuint8mf2_t vs2, vuint8mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m2_t test_vwabdau_vv_u16m2_mu(vbool8_t vm, vuint16m2_t vd,
-                                     vuint8m1_t vs1, vuint8m1_t vs2,
+                                     vuint8m1_t vs2, vuint8m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m4_t test_vwabdau_vv_u16m4_mu(vbool4_t vm, vuint16m4_t vd,
-                                     vuint8m2_t vs1, vuint8m2_t vs2,
+                                     vuint8m2_t vs2, vuint8m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint16m8_t test_vwabdau_vv_u16m8_mu(vbool2_t vm, vuint16m8_t vd,
-                                     vuint8m4_t vs1, vuint8m4_t vs2,
+                                     vuint8m4_t vs2, vuint8m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32mf2_t test_vwabdau_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                       vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                       vuint16mf4_t vs2, vuint16mf4_t vs1,
                                        size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m1_t test_vwabdau_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                     vuint16mf2_t vs1, vuint16mf2_t vs2,
+                                     vuint16mf2_t vs2, vuint16mf2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m2_t test_vwabdau_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                     vuint16m1_t vs1, vuint16m1_t vs2,
+                                     vuint16m1_t vs2, vuint16m1_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m4_t test_vwabdau_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd,
-                                     vuint16m2_t vs1, vuint16m2_t vs2,
+                                     vuint16m2_t vs2, vuint16m2_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }
 
 vuint32m8_t test_vwabdau_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
-                                     vuint16m4_t vs1, vuint16m4_t vs2,
+                                     vuint16m4_t vs2, vuint16m4_t vs1,
                                      size_t vl) {
-  return __riscv_vwabdau_mu(vm, vd, vs1, vs2, vl);
+  return __riscv_vwabdau_mu(vm, vd, vs2, vs1, vl);
 }

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs.adoc
@@ -79688,97 +79688,97 @@ vuint16m8_t __riscv_vabdu_mu(vbool2_t vm, vuint16m8_t vd, vuint16m8_t vs2,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabda_tu(vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2,
+vuint16mf4_t __riscv_vwabda_tu(vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1,
                                size_t vl);
-vuint16mf2_t __riscv_vwabda_tu(vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2,
+vuint16mf2_t __riscv_vwabda_tu(vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1,
                                size_t vl);
-vuint16m1_t __riscv_vwabda_tu(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2,
+vuint16m1_t __riscv_vwabda_tu(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
                               size_t vl);
-vuint16m2_t __riscv_vwabda_tu(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
+vuint16m2_t __riscv_vwabda_tu(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1,
                               size_t vl);
-vuint16m4_t __riscv_vwabda_tu(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2,
+vuint16m4_t __riscv_vwabda_tu(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1,
                               size_t vl);
-vuint16m8_t __riscv_vwabda_tu(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2,
+vuint16m8_t __riscv_vwabda_tu(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1,
                               size_t vl);
-vuint32mf2_t __riscv_vwabda_tu(vuint32mf2_t vd, vint16mf4_t vs1,
-                               vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_tu(vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2,
+vuint32mf2_t __riscv_vwabda_tu(vuint32mf2_t vd, vint16mf4_t vs2,
+                               vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_tu(vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1,
                               size_t vl);
-vuint32m2_t __riscv_vwabda_tu(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2,
+vuint32m2_t __riscv_vwabda_tu(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1,
                               size_t vl);
-vuint32m4_t __riscv_vwabda_tu(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2,
+vuint32m4_t __riscv_vwabda_tu(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1,
                               size_t vl);
-vuint32m8_t __riscv_vwabda_tu(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2,
+vuint32m8_t __riscv_vwabda_tu(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1,
                               size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabda_tum(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1,
-                                vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_tum(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1,
-                                vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_tum(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                               vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                               vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                               vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                               vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_tum(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1,
-                                vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_tum(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1,
-                               vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_tum(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                               vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_tum(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                               vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_tum(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                               vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_tum(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2,
+                                vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_tum(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2,
+                                vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_tum(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                               vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                               vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                               vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                               vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_tum(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2,
+                                vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_tum(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2,
+                               vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_tum(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                               vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_tum(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                               vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_tum(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                               vint16m4_t vs1, size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabda_tumu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1,
-                                 vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_tumu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1,
-                                 vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_tumu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                                vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_tumu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_tumu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_tumu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_tumu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1,
-                                 vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_tumu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1,
-                                vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_tumu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                                vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_tumu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_tumu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_tumu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2,
+                                 vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_tumu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2,
+                                 vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_tumu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                                vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_tumu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_tumu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_tumu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_tumu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2,
+                                 vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_tumu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2,
+                                vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_tumu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                                vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_tumu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_tumu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                vint16m4_t vs1, size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabda_mu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1,
-                               vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_mu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1,
-                               vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_mu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                              vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                              vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                              vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                              vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_mu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1,
-                               vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_mu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1,
-                              vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_mu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                              vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                              vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                              vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_mu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2,
+                               vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_mu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2,
+                               vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_mu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                              vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                              vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                              vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                              vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_mu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2,
+                               vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_mu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2,
+                              vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_mu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                              vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                              vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                              vint16m4_t vs1, size_t vl);
 ----
 
 [[policy-variant-overloadedvector-integer-wabdau-instructions]]
@@ -79786,98 +79786,98 @@ vuint32m8_t __riscv_vwabda_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabdau_tu(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_tu(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_tu(vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2,
+vuint16mf4_t __riscv_vwabdau_tu(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_tu(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_tu(vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1,
                                size_t vl);
-vuint16m2_t __riscv_vwabdau_tu(vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2,
+vuint16m2_t __riscv_vwabdau_tu(vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1,
                                size_t vl);
-vuint16m4_t __riscv_vwabdau_tu(vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2,
+vuint16m4_t __riscv_vwabdau_tu(vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1,
                                size_t vl);
-vuint16m8_t __riscv_vwabdau_tu(vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2,
+vuint16m8_t __riscv_vwabdau_tu(vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1,
                                size_t vl);
-vuint32mf2_t __riscv_vwabdau_tu(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_tu(vuint32m1_t vd, vuint16mf2_t vs1,
-                               vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_tu(vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2,
+vuint32mf2_t __riscv_vwabdau_tu(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_tu(vuint32m1_t vd, vuint16mf2_t vs2,
+                               vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_tu(vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1,
                                size_t vl);
-vuint32m4_t __riscv_vwabdau_tu(vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2,
+vuint32m4_t __riscv_vwabdau_tu(vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1,
                                size_t vl);
-vuint32m8_t __riscv_vwabdau_tu(vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2,
+vuint32m8_t __riscv_vwabdau_tu(vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1,
                                size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabdau_tum(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1,
-                                 vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_tum(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1,
-                                 vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_tum(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1,
-                                vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_tum(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                                vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_tum(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                                vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_tum(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                                vuint8m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau_tum(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2,
+                                 vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_tum(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2,
+                                 vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_tum(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2,
+                                vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_tum(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                                vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_tum(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                                vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_tum(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                                vuint8m4_t vs1, size_t vl);
 vuint32mf2_t __riscv_vwabdau_tum(vbool64_t vm, vuint32mf2_t vd,
-                                 vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_tum(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1,
-                                vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_tum(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1,
-                                vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_tum(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1,
-                                vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_tum(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1,
-                                vuint16m4_t vs2, size_t vl);
+                                 vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_tum(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2,
+                                vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_tum(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2,
+                                vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_tum(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2,
+                                vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_tum(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2,
+                                vuint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                  vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl);
+                                  vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl);
 vuint16mf2_t __riscv_vwabdau_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                  vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_tumu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1,
-                                 vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_tumu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                                 vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_tumu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                                 vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_tumu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                                 vuint8m4_t vs2, size_t vl);
+                                  vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_tumu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2,
+                                 vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_tumu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                                 vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_tumu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                                 vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_tumu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                                 vuint8m4_t vs1, size_t vl);
 vuint32mf2_t __riscv_vwabdau_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                  vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                  vuint16mf4_t vs2, vuint16mf4_t vs1,
                                   size_t vl);
-vuint32m1_t __riscv_vwabdau_tumu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1,
-                                 vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_tumu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1,
-                                 vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_tumu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1,
-                                 vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_tumu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1,
-                                 vuint16m4_t vs2, size_t vl);
+vuint32m1_t __riscv_vwabdau_tumu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2,
+                                 vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_tumu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2,
+                                 vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_tumu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2,
+                                 vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_tumu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2,
+                                 vuint16m4_t vs1, size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabdau_mu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1,
-                                vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_mu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1,
-                                vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_mu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1,
-                               vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_mu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                               vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_mu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                               vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_mu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                               vuint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabdau_mu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1,
-                                vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_mu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1,
-                               vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_mu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1,
-                               vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_mu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1,
-                               vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_mu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1,
-                               vuint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau_mu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2,
+                                vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_mu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2,
+                                vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_mu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2,
+                               vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_mu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                               vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_mu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                               vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_mu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                               vuint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabdau_mu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2,
+                                vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_mu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2,
+                               vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_mu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2,
+                               vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_mu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2,
+                               vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_mu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2,
+                               vuint16m4_t vs1, size_t vl);
 ----
 
 === Zvqwdota8i - 8-bit Integer Quad-Widening Dot Product

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/14_zvabd_-_vector_absolute_difference_instructions.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/14_zvabd_-_vector_absolute_difference_instructions.adoc
@@ -398,97 +398,97 @@ vuint16m8_t __riscv_vabdu_mu(vbool2_t vm, vuint16m8_t vd, vuint16m8_t vs2,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabda_tu(vuint16mf4_t vd, vint8mf8_t vs1, vint8mf8_t vs2,
+vuint16mf4_t __riscv_vwabda_tu(vuint16mf4_t vd, vint8mf8_t vs2, vint8mf8_t vs1,
                                size_t vl);
-vuint16mf2_t __riscv_vwabda_tu(vuint16mf2_t vd, vint8mf4_t vs1, vint8mf4_t vs2,
+vuint16mf2_t __riscv_vwabda_tu(vuint16mf2_t vd, vint8mf4_t vs2, vint8mf4_t vs1,
                                size_t vl);
-vuint16m1_t __riscv_vwabda_tu(vuint16m1_t vd, vint8mf2_t vs1, vint8mf2_t vs2,
+vuint16m1_t __riscv_vwabda_tu(vuint16m1_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
                               size_t vl);
-vuint16m2_t __riscv_vwabda_tu(vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2,
+vuint16m2_t __riscv_vwabda_tu(vuint16m2_t vd, vint8m1_t vs2, vint8m1_t vs1,
                               size_t vl);
-vuint16m4_t __riscv_vwabda_tu(vuint16m4_t vd, vint8m2_t vs1, vint8m2_t vs2,
+vuint16m4_t __riscv_vwabda_tu(vuint16m4_t vd, vint8m2_t vs2, vint8m2_t vs1,
                               size_t vl);
-vuint16m8_t __riscv_vwabda_tu(vuint16m8_t vd, vint8m4_t vs1, vint8m4_t vs2,
+vuint16m8_t __riscv_vwabda_tu(vuint16m8_t vd, vint8m4_t vs2, vint8m4_t vs1,
                               size_t vl);
-vuint32mf2_t __riscv_vwabda_tu(vuint32mf2_t vd, vint16mf4_t vs1,
-                               vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_tu(vuint32m1_t vd, vint16mf2_t vs1, vint16mf2_t vs2,
+vuint32mf2_t __riscv_vwabda_tu(vuint32mf2_t vd, vint16mf4_t vs2,
+                               vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_tu(vuint32m1_t vd, vint16mf2_t vs2, vint16mf2_t vs1,
                               size_t vl);
-vuint32m2_t __riscv_vwabda_tu(vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2,
+vuint32m2_t __riscv_vwabda_tu(vuint32m2_t vd, vint16m1_t vs2, vint16m1_t vs1,
                               size_t vl);
-vuint32m4_t __riscv_vwabda_tu(vuint32m4_t vd, vint16m2_t vs1, vint16m2_t vs2,
+vuint32m4_t __riscv_vwabda_tu(vuint32m4_t vd, vint16m2_t vs2, vint16m2_t vs1,
                               size_t vl);
-vuint32m8_t __riscv_vwabda_tu(vuint32m8_t vd, vint16m4_t vs1, vint16m4_t vs2,
+vuint32m8_t __riscv_vwabda_tu(vuint32m8_t vd, vint16m4_t vs2, vint16m4_t vs1,
                               size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabda_tum(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1,
-                                vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_tum(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1,
-                                vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_tum(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                               vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                               vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                               vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                               vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_tum(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1,
-                                vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_tum(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1,
-                               vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_tum(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                               vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_tum(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                               vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_tum(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                               vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_tum(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2,
+                                vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_tum(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2,
+                                vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_tum(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                               vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_tum(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                               vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_tum(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                               vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_tum(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                               vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_tum(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2,
+                                vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_tum(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2,
+                               vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_tum(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                               vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_tum(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                               vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_tum(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                               vint16m4_t vs1, size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabda_tumu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1,
-                                 vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_tumu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1,
-                                 vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_tumu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                                vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_tumu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                                vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_tumu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                                vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_tumu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                                vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_tumu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1,
-                                 vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_tumu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1,
-                                vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_tumu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                                vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_tumu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                                vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_tumu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                                vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_tumu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2,
+                                 vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_tumu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2,
+                                 vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_tumu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                                vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_tumu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                                vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_tumu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                                vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_tumu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                                vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_tumu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2,
+                                 vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_tumu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2,
+                                vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_tumu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                                vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_tumu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                                vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_tumu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                                vint16m4_t vs1, size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabda_mu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs1,
-                               vint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabda_mu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs1,
-                               vint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabda_mu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs1,
-                              vint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabda_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs1,
-                              vint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabda_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs1,
-                              vint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabda_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs1,
-                              vint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabda_mu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs1,
-                               vint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabda_mu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs1,
-                              vint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabda_mu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs1,
-                              vint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabda_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs1,
-                              vint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabda_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
-                              vint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabda_mu(vbool64_t vm, vuint16mf4_t vd, vint8mf8_t vs2,
+                               vint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabda_mu(vbool32_t vm, vuint16mf2_t vd, vint8mf4_t vs2,
+                               vint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabda_mu(vbool16_t vm, vuint16m1_t vd, vint8mf2_t vs2,
+                              vint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabda_mu(vbool8_t vm, vuint16m2_t vd, vint8m1_t vs2,
+                              vint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabda_mu(vbool4_t vm, vuint16m4_t vd, vint8m2_t vs2,
+                              vint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabda_mu(vbool2_t vm, vuint16m8_t vd, vint8m4_t vs2,
+                              vint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabda_mu(vbool64_t vm, vuint32mf2_t vd, vint16mf4_t vs2,
+                               vint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabda_mu(vbool32_t vm, vuint32m1_t vd, vint16mf2_t vs2,
+                              vint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabda_mu(vbool16_t vm, vuint32m2_t vd, vint16m1_t vs2,
+                              vint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabda_mu(vbool8_t vm, vuint32m4_t vd, vint16m2_t vs2,
+                              vint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabda_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs2,
+                              vint16m4_t vs1, size_t vl);
 ----
 
 [[policy-variant-overloadedvector-integer-wabdau-instructions]]
@@ -496,96 +496,96 @@ vuint32m8_t __riscv_vwabda_mu(vbool4_t vm, vuint32m8_t vd, vint16m4_t vs1,
 
 [,c]
 ----
-vuint16mf4_t __riscv_vwabdau_tu(vuint16mf4_t vd, vuint8mf8_t vs1,
-                                vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_tu(vuint16mf2_t vd, vuint8mf4_t vs1,
-                                vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_tu(vuint16m1_t vd, vuint8mf2_t vs1, vuint8mf2_t vs2,
+vuint16mf4_t __riscv_vwabdau_tu(vuint16mf4_t vd, vuint8mf8_t vs2,
+                                vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_tu(vuint16mf2_t vd, vuint8mf4_t vs2,
+                                vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_tu(vuint16m1_t vd, vuint8mf2_t vs2, vuint8mf2_t vs1,
                                size_t vl);
-vuint16m2_t __riscv_vwabdau_tu(vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2,
+vuint16m2_t __riscv_vwabdau_tu(vuint16m2_t vd, vuint8m1_t vs2, vuint8m1_t vs1,
                                size_t vl);
-vuint16m4_t __riscv_vwabdau_tu(vuint16m4_t vd, vuint8m2_t vs1, vuint8m2_t vs2,
+vuint16m4_t __riscv_vwabdau_tu(vuint16m4_t vd, vuint8m2_t vs2, vuint8m2_t vs1,
                                size_t vl);
-vuint16m8_t __riscv_vwabdau_tu(vuint16m8_t vd, vuint8m4_t vs1, vuint8m4_t vs2,
+vuint16m8_t __riscv_vwabdau_tu(vuint16m8_t vd, vuint8m4_t vs2, vuint8m4_t vs1,
                                size_t vl);
-vuint32mf2_t __riscv_vwabdau_tu(vuint32mf2_t vd, vuint16mf4_t vs1,
-                                vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_tu(vuint32m1_t vd, vuint16mf2_t vs1,
-                               vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_tu(vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2,
+vuint32mf2_t __riscv_vwabdau_tu(vuint32mf2_t vd, vuint16mf4_t vs2,
+                                vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_tu(vuint32m1_t vd, vuint16mf2_t vs2,
+                               vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_tu(vuint32m2_t vd, vuint16m1_t vs2, vuint16m1_t vs1,
                                size_t vl);
-vuint32m4_t __riscv_vwabdau_tu(vuint32m4_t vd, vuint16m2_t vs1, vuint16m2_t vs2,
+vuint32m4_t __riscv_vwabdau_tu(vuint32m4_t vd, vuint16m2_t vs2, vuint16m2_t vs1,
                                size_t vl);
-vuint32m8_t __riscv_vwabdau_tu(vuint32m8_t vd, vuint16m4_t vs1, vuint16m4_t vs2,
+vuint32m8_t __riscv_vwabdau_tu(vuint32m8_t vd, vuint16m4_t vs2, vuint16m4_t vs1,
                                size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabdau_tum(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1,
-                                 vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_tum(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1,
-                                 vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_tum(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1,
-                                vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_tum(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                                vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_tum(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                                vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_tum(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                                vuint8m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau_tum(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2,
+                                 vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_tum(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2,
+                                 vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_tum(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2,
+                                vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_tum(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                                vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_tum(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                                vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_tum(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                                vuint8m4_t vs1, size_t vl);
 vuint32mf2_t __riscv_vwabdau_tum(vbool64_t vm, vuint32mf2_t vd,
-                                 vuint16mf4_t vs1, vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_tum(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1,
-                                vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_tum(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1,
-                                vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_tum(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1,
-                                vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_tum(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1,
-                                vuint16m4_t vs2, size_t vl);
+                                 vuint16mf4_t vs2, vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_tum(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2,
+                                vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_tum(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2,
+                                vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_tum(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2,
+                                vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_tum(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2,
+                                vuint16m4_t vs1, size_t vl);
 // masked functions
 vuint16mf4_t __riscv_vwabdau_tumu(vbool64_t vm, vuint16mf4_t vd,
-                                  vuint8mf8_t vs1, vuint8mf8_t vs2, size_t vl);
+                                  vuint8mf8_t vs2, vuint8mf8_t vs1, size_t vl);
 vuint16mf2_t __riscv_vwabdau_tumu(vbool32_t vm, vuint16mf2_t vd,
-                                  vuint8mf4_t vs1, vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_tumu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1,
-                                 vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_tumu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                                 vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_tumu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                                 vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_tumu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                                 vuint8m4_t vs2, size_t vl);
+                                  vuint8mf4_t vs2, vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_tumu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2,
+                                 vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_tumu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                                 vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_tumu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                                 vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_tumu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                                 vuint8m4_t vs1, size_t vl);
 vuint32mf2_t __riscv_vwabdau_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                  vuint16mf4_t vs1, vuint16mf4_t vs2,
+                                  vuint16mf4_t vs2, vuint16mf4_t vs1,
                                   size_t vl);
-vuint32m1_t __riscv_vwabdau_tumu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1,
-                                 vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_tumu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1,
-                                 vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_tumu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1,
-                                 vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_tumu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1,
-                                 vuint16m4_t vs2, size_t vl);
+vuint32m1_t __riscv_vwabdau_tumu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2,
+                                 vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_tumu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2,
+                                 vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_tumu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2,
+                                 vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_tumu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2,
+                                 vuint16m4_t vs1, size_t vl);
 // masked functions
-vuint16mf4_t __riscv_vwabdau_mu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs1,
-                                vuint8mf8_t vs2, size_t vl);
-vuint16mf2_t __riscv_vwabdau_mu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs1,
-                                vuint8mf4_t vs2, size_t vl);
-vuint16m1_t __riscv_vwabdau_mu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs1,
-                               vuint8mf2_t vs2, size_t vl);
-vuint16m2_t __riscv_vwabdau_mu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs1,
-                               vuint8m1_t vs2, size_t vl);
-vuint16m4_t __riscv_vwabdau_mu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs1,
-                               vuint8m2_t vs2, size_t vl);
-vuint16m8_t __riscv_vwabdau_mu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs1,
-                               vuint8m4_t vs2, size_t vl);
-vuint32mf2_t __riscv_vwabdau_mu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs1,
-                                vuint16mf4_t vs2, size_t vl);
-vuint32m1_t __riscv_vwabdau_mu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs1,
-                               vuint16mf2_t vs2, size_t vl);
-vuint32m2_t __riscv_vwabdau_mu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs1,
-                               vuint16m1_t vs2, size_t vl);
-vuint32m4_t __riscv_vwabdau_mu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs1,
-                               vuint16m2_t vs2, size_t vl);
-vuint32m8_t __riscv_vwabdau_mu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs1,
-                               vuint16m4_t vs2, size_t vl);
+vuint16mf4_t __riscv_vwabdau_mu(vbool64_t vm, vuint16mf4_t vd, vuint8mf8_t vs2,
+                                vuint8mf8_t vs1, size_t vl);
+vuint16mf2_t __riscv_vwabdau_mu(vbool32_t vm, vuint16mf2_t vd, vuint8mf4_t vs2,
+                                vuint8mf4_t vs1, size_t vl);
+vuint16m1_t __riscv_vwabdau_mu(vbool16_t vm, vuint16m1_t vd, vuint8mf2_t vs2,
+                               vuint8mf2_t vs1, size_t vl);
+vuint16m2_t __riscv_vwabdau_mu(vbool8_t vm, vuint16m2_t vd, vuint8m1_t vs2,
+                               vuint8m1_t vs1, size_t vl);
+vuint16m4_t __riscv_vwabdau_mu(vbool4_t vm, vuint16m4_t vd, vuint8m2_t vs2,
+                               vuint8m2_t vs1, size_t vl);
+vuint16m8_t __riscv_vwabdau_mu(vbool2_t vm, vuint16m8_t vd, vuint8m4_t vs2,
+                               vuint8m4_t vs1, size_t vl);
+vuint32mf2_t __riscv_vwabdau_mu(vbool64_t vm, vuint32mf2_t vd, vuint16mf4_t vs2,
+                                vuint16mf4_t vs1, size_t vl);
+vuint32m1_t __riscv_vwabdau_mu(vbool32_t vm, vuint32m1_t vd, vuint16mf2_t vs2,
+                               vuint16mf2_t vs1, size_t vl);
+vuint32m2_t __riscv_vwabdau_mu(vbool16_t vm, vuint32m2_t vd, vuint16m1_t vs2,
+                               vuint16m1_t vs1, size_t vl);
+vuint32m4_t __riscv_vwabdau_mu(vbool8_t vm, vuint32m4_t vd, vuint16m2_t vs2,
+                               vuint16m2_t vs1, size_t vl);
+vuint32m8_t __riscv_vwabdau_mu(vbool4_t vm, vuint32m8_t vd, vuint16m4_t vs2,
+                               vuint16m4_t vs1, size_t vl);
 ----

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/mac_template.py
@@ -215,8 +215,8 @@ def render(G,
               return_type=type_helper.uwiv,
               **decorator.mask_args(type_helper.m, type_helper.uwiv),
               vd=type_helper.uwiv,
-              vs1=type_helper.v,
               vs2=type_helper.v,
+              vs1=type_helper.v,
               vl=type_helper.size_t)
       elif data_type in ["float", "bfloat"] and "w" in op:
         if data_type == "bfloat":


### PR DESCRIPTION
The current vwabda[u] intrinsics are using the vmacc-like `vs1, vs2` operand order, while the asm operand order in the current Zvabd specification is `vs2, vs1`. I guess we should be consistent with the Zvabd spec?